### PR TITLE
Streamline block reads, do CRC more on the fly.

### DIFF
--- a/cpp/core/MsgsGen.cpp
+++ b/cpp/core/MsgsGen.cpp
@@ -5208,36 +5208,36 @@ std::ostream& operator<<(std::ostream& out, const WriteBlockResp& x) {
 }
 
 void FetchBlockWithCrcReq::pack(BincodeBuf& buf) const {
-    fileId.pack(buf);
+    fileIdUnused.pack(buf);
     buf.packScalar<uint64_t>(blockId);
-    blockCrc.pack(buf);
+    blockCrcUnused.pack(buf);
     buf.packScalar<uint32_t>(offset);
     buf.packScalar<uint32_t>(count);
 }
 void FetchBlockWithCrcReq::unpack(BincodeBuf& buf) {
-    fileId.unpack(buf);
+    fileIdUnused.unpack(buf);
     blockId = buf.unpackScalar<uint64_t>();
-    blockCrc.unpack(buf);
+    blockCrcUnused.unpack(buf);
     offset = buf.unpackScalar<uint32_t>();
     count = buf.unpackScalar<uint32_t>();
 }
 void FetchBlockWithCrcReq::clear() {
-    fileId = InodeId();
+    fileIdUnused = InodeId();
     blockId = uint64_t(0);
-    blockCrc = Crc(0);
+    blockCrcUnused = Crc(0);
     offset = uint32_t(0);
     count = uint32_t(0);
 }
 bool FetchBlockWithCrcReq::operator==(const FetchBlockWithCrcReq& rhs) const {
-    if ((InodeId)this->fileId != (InodeId)rhs.fileId) { return false; };
+    if ((InodeId)this->fileIdUnused != (InodeId)rhs.fileIdUnused) { return false; };
     if ((uint64_t)this->blockId != (uint64_t)rhs.blockId) { return false; };
-    if ((Crc)this->blockCrc != (Crc)rhs.blockCrc) { return false; };
+    if ((Crc)this->blockCrcUnused != (Crc)rhs.blockCrcUnused) { return false; };
     if ((uint32_t)this->offset != (uint32_t)rhs.offset) { return false; };
     if ((uint32_t)this->count != (uint32_t)rhs.count) { return false; };
     return true;
 }
 std::ostream& operator<<(std::ostream& out, const FetchBlockWithCrcReq& x) {
-    out << "FetchBlockWithCrcReq(" << "FileId=" << x.fileId << ", " << "BlockId=" << x.blockId << ", " << "BlockCrc=" << x.blockCrc << ", " << "Offset=" << x.offset << ", " << "Count=" << x.count << ")";
+    out << "FetchBlockWithCrcReq(" << "FileIdUnused=" << x.fileIdUnused << ", " << "BlockId=" << x.blockId << ", " << "BlockCrcUnused=" << x.blockCrcUnused << ", " << "Offset=" << x.offset << ", " << "Count=" << x.count << ")";
     return out;
 }
 

--- a/cpp/core/MsgsGen.hpp
+++ b/cpp/core/MsgsGen.hpp
@@ -4927,20 +4927,20 @@ struct WriteBlockResp {
 std::ostream& operator<<(std::ostream& out, const WriteBlockResp& x);
 
 struct FetchBlockWithCrcReq {
-    InodeId fileId;
+    InodeId fileIdUnused;
     uint64_t blockId;
-    Crc blockCrc;
+    Crc blockCrcUnused;
     uint32_t offset;
     uint32_t count;
 
-    static constexpr uint16_t STATIC_SIZE = 8 + 8 + 4 + 4 + 4; // fileId + blockId + blockCrc + offset + count
+    static constexpr uint16_t STATIC_SIZE = 8 + 8 + 4 + 4 + 4; // fileIdUnused + blockId + blockCrcUnused + offset + count
 
     FetchBlockWithCrcReq() { clear(); }
     size_t packedSize() const {
         size_t _size = 0;
-        _size += 8; // fileId
+        _size += 8; // fileIdUnused
         _size += 8; // blockId
-        _size += 4; // blockCrc
+        _size += 4; // blockCrcUnused
         _size += 4; // offset
         _size += 4; // count
         return _size;

--- a/go/client/span.go
+++ b/go/client/span.go
@@ -472,27 +472,19 @@ func (c *Client) fetchCell(
 	body *msgs.FetchedBlocksSpan,
 	blockIx uint8,
 	cell uint8,
-) (buf *bufpool.Buf, err error) {
-	buf = bufPool.Get(int(body.CellSize))
+) (buf *bufpool.Buf, crc msgs.Crc, err error) {
+	br := NewBlockReader(bufPool, uint32(cell)*body.CellSize, body.CellSize)
 	defer func() {
-		if err != nil {
-			bufPool.Put(buf)
-		}
+		bufPool.Put(br.AcquireBuf())
 	}()
 	block := &body.Blocks[blockIx]
 	blockService := &blockServices[block.BlockServiceIx]
-	var data *bytes.Buffer
 	// fail immediately to other block services
-	data, err = c.FetchBlock(log, &timing.NoTimeouts, blockService, block.BlockId, uint32(cell)*body.CellSize, body.CellSize, block.Crc)
-	if err != nil {
+	if err := c.FetchBlock(log, &timing.NoTimeouts, blockService, block.BlockId, uint32(cell)*body.CellSize, body.CellSize, br); err != nil {
 		log.Info("could not fetch block from block service %+v: %+v", blockService, err)
-		return nil, err
+		return nil, 0, err
 	}
-	defer c.PutFetchedBlock(data)
-	if copy(buf.Bytes(), data.Bytes()) != int(body.CellSize) {
-		panic(fmt.Errorf("runt block cell"))
-	}
-	return buf, nil
+	return br.AcquireBuf(), br.Crc(), nil
 }
 
 func (c *Client) fetchMirroredStripe(
@@ -516,14 +508,14 @@ func (c *Client) fetchMirroredStripe(
 		if !blockService.Flags.CanRead() {
 			continue
 		}
-		buf, err = c.fetchCell(log, bufPool, span.BlockServices, body, uint8(i), uint8(cell))
+		var crc msgs.Crc
+		buf, crc, err = c.fetchCell(log, bufPool, span.BlockServices, body, uint8(i), uint8(cell))
 		if err != nil {
 			continue
 		}
-		crc := msgs.Crc(crc32c.Sum(0, buf.Bytes()))
 		if crc != body.StripesCrc[cell] {
-			log.RaiseAlert("expected crc %v, got %v, for block %v in block service %v", body.StripesCrc[cell], crc, block.BlockId, blockService.Id)
-			continue
+			// we check the block pages page-by-page
+			panic(fmt.Errorf("expected crc %v, got %v, for block %v in block service %v", body.StripesCrc[cell], crc, block.BlockId, blockService.Id))
 		}
 		found = true
 	}
@@ -547,6 +539,7 @@ func (c *Client) fetchRsStripe(
 	B := body.Parity.Blocks()
 	spanOffset := uint32(offset - span.Span.Header.ByteOffset)
 	blocks := make([]*bufpool.Buf, B)
+	crcs := make([]msgs.Crc, B)
 	defer func() {
 		for i := range blocks {
 			bufPool.Put(blocks[i])
@@ -564,7 +557,7 @@ func (c *Client) fetchRsStripe(
 		if !blockService.Flags.CanRead() {
 			continue
 		}
-		buf, err = c.fetchCell(log, bufPool, span.BlockServices, body, uint8(i), uint8(stripe))
+		buf, crcs[i], err = c.fetchCell(log, bufPool, span.BlockServices, body, uint8(i), uint8(stripe))
 		if err != nil {
 			continue
 		}
@@ -598,15 +591,16 @@ func (c *Client) fetchRsStripe(
 			}
 			blocks[i] = bufPool.Get(int(body.CellSize))
 			rs.Get(body.Parity).RecoverInto(haveBlocksRecoverIxs, haveBlocksRecover, uint8(i), blocks[i].Bytes())
+			crcs[i] = msgs.Crc(crc32c.Sum(0, blocks[i].Bytes()))
 		}
-		stripeCrc = crc32c.Sum(stripeCrc, blocks[i].Bytes())
 		copy(stripeBuf.Bytes()[i*int(body.CellSize):(i+1)*int(body.CellSize)], blocks[i].Bytes())
+		stripeCrc = crc32c.Append(stripeCrc, uint32(crcs[i]), int(body.CellSize))
 	}
 
 	// check if our crc is scuppered
 	if stripeCrc != uint32(body.StripesCrc[stripe]) {
-		// TODO implement corrupted stripe repair
-		return 0, nil, fmt.Errorf("bad crc, expected %v, got %v", msgs.Crc(stripeCrc), body.StripesCrc[stripe])
+		// we check the block pages page-py-page
+		panic(fmt.Errorf("bad crc, expected %v, got %v", msgs.Crc(stripeCrc), body.StripesCrc[stripe]))
 	}
 
 	return span.Span.Header.ByteOffset + uint64(stripe)*uint64(D)*uint64(body.CellSize), stripeBuf, nil
@@ -720,14 +714,11 @@ func (c *Client) fetchMirroredSpan(log *log.Logger,
 		if !blockService.Flags.CanRead() {
 			continue
 		}
-		data, err := c.FetchBlock(log, nil, blockService, block.BlockId, 0, blockSize, block.Crc)
-		if err == nil {
-			defer c.PutFetchedBlock(data)
-			if copy(buf.Bytes(), data.Bytes()) != int(span.Span.Header.Size) {
-				panic(fmt.Errorf("runt block"))
-			}
-			return buf, nil
+		br := NewBlockReader(bufPool, 0, blockSize)
+		if err := c.FetchBlock(log, nil, blockService, block.BlockId, 0, blockSize, br); err == nil {
+			return br.AcquireBuf(), nil
 		}
+		bufPool.Put(br.AcquireBuf())
 	}
 	return nil, fmt.Errorf("could not find any suitable blocks")
 }
@@ -747,14 +738,17 @@ func (c *Client) fetchRsSpan(log *log.Logger,
 	var inFlightBlocks int
 	var blockIdx int
 	dataBlocks := body.Parity.DataBlocks()
-	blockBufs := make([]*bytes.Buffer, body.Parity.Blocks())
+	blockBufs := make([]*bufpool.Buf, body.Parity.Blocks())
 	defer func() {
-		for _, buf := range blockBufs {
-			if buf != nil {
-				c.fetchBlockBufs.Put(buf)
-			}
+		for i := range blockBufs {
+			bufPool.Put(blockBufs[i])
 		}
 	}()
+
+	type blockReaderWithIx struct {
+		ix int
+		br *BlockReader
+	}
 
 scheduleMoreBlocks:
 	for succeedBlocks+inFlightBlocks < dataBlocks && blockIdx < body.Parity.Blocks() {
@@ -764,10 +758,11 @@ scheduleMoreBlocks:
 			blockIdx++
 			continue
 		}
-		blockBufs[blockIdx] = c.fetchBlockBufs.Get().(*bytes.Buffer)
-		blockBufs[blockIdx].Reset()
-		extra := blockIdx
-		if err := c.StartFetchBlock(log, blockService, block.BlockId, 0, blockSize, blockBufs[blockIdx], &extra, ch, block.Crc); err == nil {
+		readerWithIx := blockReaderWithIx{
+			ix: blockIdx,
+			br: NewBlockReader(bufPool, 0, blockSize),
+		}
+		if err := c.StartFetchBlock(log, blockService, block.BlockId, 0, blockSize, readerWithIx.br, &readerWithIx, ch); err == nil {
 			inFlightBlocks++
 		}
 		blockIdx++
@@ -776,12 +771,13 @@ scheduleMoreBlocks:
 	for inFlightBlocks > 0 {
 		result := <-ch
 		inFlightBlocks--
-		idx := *result.Extra.(*int)
+		readerWithIx := result.Extra.(*blockReaderWithIx)
+		buf := readerWithIx.br.AcquireBuf()
 		if result.Error != nil {
-			c.PutFetchedBlock(blockBufs[idx])
-			blockBufs[idx] = nil
+			bufPool.Put(buf)
 			goto scheduleMoreBlocks
 		}
+		blockBufs[readerWithIx.ix] = buf
 		succeedBlocks++
 	}
 
@@ -803,16 +799,13 @@ scheduleMoreBlocks:
 		if blockBufs[i] != nil {
 			continue
 		}
-		blockBufs[i] = c.fetchBlockBufs.Get().(*bytes.Buffer)
-		blockBufs[i].Reset()
-		blockBufs[i].Write(make([]byte, blockSize))
+		blockBufs[i] = bufPool.Get(int(blockSize))
 		rs.Get(body.Parity).RecoverInto(haveBlocksRecoverIxs, haveBlocksRecover, uint8(i), blockBufs[i].Bytes())
 	}
 
 	buf := bufPool.Get(int(span.Span.Header.Size))
-	for i := dataSize; i < span.Span.Header.Size; i++ {
-		buf.Bytes()[i] = 0
-	}
+	clear(buf.Bytes()[min(span.Span.Header.Size, dataSize):]) // zero pad
+
 	spanOffset := 0
 	blockOffset := 0
 	for range body.Stripes {
@@ -824,11 +817,6 @@ scheduleMoreBlocks:
 			spanOffset += int(body.CellSize)
 		}
 		blockOffset += int(body.CellSize)
-	}
-
-	dataCrc := msgs.Crc(crc32c.Sum(0, buf.Bytes()))
-	if dataCrc != span.Span.Header.Crc {
-		return nil, fmt.Errorf("header CRC for span is %v, but data is %v", span.Span.Header.Crc, dataCrc)
 	}
 
 	return buf, nil

--- a/go/msgs/msgs.go
+++ b/go/msgs/msgs.go
@@ -2060,7 +2060,7 @@ type FullRegistryInfo struct {
 	LastSeen   TernTime
 }
 
-type AllRegistryReplicasReq struct {}
+type AllRegistryReplicasReq struct{}
 
 type AllRegistryReplicasResp struct {
 	Replicas []FullRegistryInfo
@@ -2133,8 +2133,8 @@ type FullBlockServiceInfo struct {
 	CapacityBytes  uint64
 	AvailableBytes uint64
 	Blocks         uint64 // how many blocks we have
-	FirstSeen	   TernTime
-	LastSeen	   TernTime
+	FirstSeen      TernTime
+	LastSeen       TernTime
 	LastInfoChange TernTime // change to read/write status or addresses
 	HasFiles       bool
 	Path           string
@@ -2367,12 +2367,14 @@ type FetchBlockReq struct {
 type FetchBlockResp struct{}
 
 // Offset needs to be multiple of 4K and count as well
+// FileId/BlockCrc were used in the transition to pages + CRC,
+// they're now unused.
 type FetchBlockWithCrcReq struct {
-	FileId   InodeId
-	BlockId  BlockId
-	BlockCrc Crc
-	Offset   uint32
-	Count    uint32
+	FileIdUnused   InodeId
+	BlockId        BlockId
+	BlockCrcUnused Crc
+	Offset         uint32
+	Count          uint32
 }
 
 // Followed by data with CRC inserted after every 4K

--- a/go/msgs/msgs_bincode.go
+++ b/go/msgs/msgs_bincode.go
@@ -6568,13 +6568,13 @@ func (v *FetchBlockWithCrcReq) BlocksRequestKind() BlocksMessageKind {
 }
 
 func (v *FetchBlockWithCrcReq) Pack(w io.Writer) error {
-	if err := bincode.PackScalar(w, uint64(v.FileId)); err != nil {
+	if err := bincode.PackScalar(w, uint64(v.FileIdUnused)); err != nil {
 		return err
 	}
 	if err := bincode.PackScalar(w, uint64(v.BlockId)); err != nil {
 		return err
 	}
-	if err := bincode.PackScalar(w, uint32(v.BlockCrc)); err != nil {
+	if err := bincode.PackScalar(w, uint32(v.BlockCrcUnused)); err != nil {
 		return err
 	}
 	if err := bincode.PackScalar(w, uint32(v.Offset)); err != nil {
@@ -6587,13 +6587,13 @@ func (v *FetchBlockWithCrcReq) Pack(w io.Writer) error {
 }
 
 func (v *FetchBlockWithCrcReq) Unpack(r io.Reader) error {
-	if err := bincode.UnpackScalar(r, (*uint64)(&v.FileId)); err != nil {
+	if err := bincode.UnpackScalar(r, (*uint64)(&v.FileIdUnused)); err != nil {
 		return err
 	}
 	if err := bincode.UnpackScalar(r, (*uint64)(&v.BlockId)); err != nil {
 		return err
 	}
-	if err := bincode.UnpackScalar(r, (*uint32)(&v.BlockCrc)); err != nil {
+	if err := bincode.UnpackScalar(r, (*uint32)(&v.BlockCrcUnused)); err != nil {
 		return err
 	}
 	if err := bincode.UnpackScalar(r, (*uint32)(&v.Offset)); err != nil {

--- a/kmod/bincodegen.h
+++ b/kmod/bincodegen.h
@@ -6843,8 +6843,8 @@ static inline void _ternfs_write_block_resp_put_proof(struct ternfs_bincode_put_
 struct ternfs_fetch_block_with_crc_req_start;
 #define ternfs_fetch_block_with_crc_req_get_start(ctx, start) struct ternfs_fetch_block_with_crc_req_start* start = NULL
 
-struct ternfs_fetch_block_with_crc_req_file_id { u64 x; };
-static inline void _ternfs_fetch_block_with_crc_req_get_file_id(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_start** prev, struct ternfs_fetch_block_with_crc_req_file_id* next) {
+struct ternfs_fetch_block_with_crc_req_file_id_unused { u64 x; };
+static inline void _ternfs_fetch_block_with_crc_req_get_file_id_unused(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_start** prev, struct ternfs_fetch_block_with_crc_req_file_id_unused* next) {
     if (likely(ctx->err == 0)) {
         if (unlikely(ctx->end - ctx->buf < 8)) {
             ctx->err = TERNFS_ERR_MALFORMED_RESPONSE;
@@ -6854,12 +6854,12 @@ static inline void _ternfs_fetch_block_with_crc_req_get_file_id(struct ternfs_bi
         }
     }
 }
-#define ternfs_fetch_block_with_crc_req_get_file_id(ctx, prev, next) \
-    struct ternfs_fetch_block_with_crc_req_file_id next; \
-    _ternfs_fetch_block_with_crc_req_get_file_id(ctx, &(prev), &(next))
+#define ternfs_fetch_block_with_crc_req_get_file_id_unused(ctx, prev, next) \
+    struct ternfs_fetch_block_with_crc_req_file_id_unused next; \
+    _ternfs_fetch_block_with_crc_req_get_file_id_unused(ctx, &(prev), &(next))
 
 struct ternfs_fetch_block_with_crc_req_block_id { u64 x; };
-static inline void _ternfs_fetch_block_with_crc_req_get_block_id(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_file_id* prev, struct ternfs_fetch_block_with_crc_req_block_id* next) {
+static inline void _ternfs_fetch_block_with_crc_req_get_block_id(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_file_id_unused* prev, struct ternfs_fetch_block_with_crc_req_block_id* next) {
     if (likely(ctx->err == 0)) {
         if (unlikely(ctx->end - ctx->buf < 8)) {
             ctx->err = TERNFS_ERR_MALFORMED_RESPONSE;
@@ -6873,8 +6873,8 @@ static inline void _ternfs_fetch_block_with_crc_req_get_block_id(struct ternfs_b
     struct ternfs_fetch_block_with_crc_req_block_id next; \
     _ternfs_fetch_block_with_crc_req_get_block_id(ctx, &(prev), &(next))
 
-struct ternfs_fetch_block_with_crc_req_block_crc { u32 x; };
-static inline void _ternfs_fetch_block_with_crc_req_get_block_crc(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_id* prev, struct ternfs_fetch_block_with_crc_req_block_crc* next) {
+struct ternfs_fetch_block_with_crc_req_block_crc_unused { u32 x; };
+static inline void _ternfs_fetch_block_with_crc_req_get_block_crc_unused(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_id* prev, struct ternfs_fetch_block_with_crc_req_block_crc_unused* next) {
     if (likely(ctx->err == 0)) {
         if (unlikely(ctx->end - ctx->buf < 4)) {
             ctx->err = TERNFS_ERR_MALFORMED_RESPONSE;
@@ -6884,12 +6884,12 @@ static inline void _ternfs_fetch_block_with_crc_req_get_block_crc(struct ternfs_
         }
     }
 }
-#define ternfs_fetch_block_with_crc_req_get_block_crc(ctx, prev, next) \
-    struct ternfs_fetch_block_with_crc_req_block_crc next; \
-    _ternfs_fetch_block_with_crc_req_get_block_crc(ctx, &(prev), &(next))
+#define ternfs_fetch_block_with_crc_req_get_block_crc_unused(ctx, prev, next) \
+    struct ternfs_fetch_block_with_crc_req_block_crc_unused next; \
+    _ternfs_fetch_block_with_crc_req_get_block_crc_unused(ctx, &(prev), &(next))
 
 struct ternfs_fetch_block_with_crc_req_offset { u32 x; };
-static inline void _ternfs_fetch_block_with_crc_req_get_offset(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_crc* prev, struct ternfs_fetch_block_with_crc_req_offset* next) {
+static inline void _ternfs_fetch_block_with_crc_req_get_offset(struct ternfs_bincode_get_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_crc_unused* prev, struct ternfs_fetch_block_with_crc_req_offset* next) {
     if (likely(ctx->err == 0)) {
         if (unlikely(ctx->end - ctx->buf < 4)) {
             ctx->err = TERNFS_ERR_MALFORMED_RESPONSE;
@@ -6931,17 +6931,17 @@ static inline void ternfs_fetch_block_with_crc_req_get_finish(struct ternfs_binc
 
 #define ternfs_fetch_block_with_crc_req_put_start(ctx, start) struct ternfs_fetch_block_with_crc_req_start* start = NULL
 
-static inline void _ternfs_fetch_block_with_crc_req_put_file_id(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_start** prev, struct ternfs_fetch_block_with_crc_req_file_id* next, u64 x) {
+static inline void _ternfs_fetch_block_with_crc_req_put_file_id_unused(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_start** prev, struct ternfs_fetch_block_with_crc_req_file_id_unused* next, u64 x) {
     next = NULL;
     BUG_ON(ctx->end - ctx->cursor < 8);
     put_unaligned_le64(x, ctx->cursor);
     ctx->cursor += 8;
 }
-#define ternfs_fetch_block_with_crc_req_put_file_id(ctx, prev, next, x) \
-    struct ternfs_fetch_block_with_crc_req_file_id next; \
-    _ternfs_fetch_block_with_crc_req_put_file_id(ctx, &(prev), &(next), x)
+#define ternfs_fetch_block_with_crc_req_put_file_id_unused(ctx, prev, next, x) \
+    struct ternfs_fetch_block_with_crc_req_file_id_unused next; \
+    _ternfs_fetch_block_with_crc_req_put_file_id_unused(ctx, &(prev), &(next), x)
 
-static inline void _ternfs_fetch_block_with_crc_req_put_block_id(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_file_id* prev, struct ternfs_fetch_block_with_crc_req_block_id* next, u64 x) {
+static inline void _ternfs_fetch_block_with_crc_req_put_block_id(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_file_id_unused* prev, struct ternfs_fetch_block_with_crc_req_block_id* next, u64 x) {
     next = NULL;
     BUG_ON(ctx->end - ctx->cursor < 8);
     put_unaligned_le64(x, ctx->cursor);
@@ -6951,17 +6951,17 @@ static inline void _ternfs_fetch_block_with_crc_req_put_block_id(struct ternfs_b
     struct ternfs_fetch_block_with_crc_req_block_id next; \
     _ternfs_fetch_block_with_crc_req_put_block_id(ctx, &(prev), &(next), x)
 
-static inline void _ternfs_fetch_block_with_crc_req_put_block_crc(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_id* prev, struct ternfs_fetch_block_with_crc_req_block_crc* next, u32 x) {
+static inline void _ternfs_fetch_block_with_crc_req_put_block_crc_unused(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_id* prev, struct ternfs_fetch_block_with_crc_req_block_crc_unused* next, u32 x) {
     next = NULL;
     BUG_ON(ctx->end - ctx->cursor < 4);
     put_unaligned_le32(x, ctx->cursor);
     ctx->cursor += 4;
 }
-#define ternfs_fetch_block_with_crc_req_put_block_crc(ctx, prev, next, x) \
-    struct ternfs_fetch_block_with_crc_req_block_crc next; \
-    _ternfs_fetch_block_with_crc_req_put_block_crc(ctx, &(prev), &(next), x)
+#define ternfs_fetch_block_with_crc_req_put_block_crc_unused(ctx, prev, next, x) \
+    struct ternfs_fetch_block_with_crc_req_block_crc_unused next; \
+    _ternfs_fetch_block_with_crc_req_put_block_crc_unused(ctx, &(prev), &(next), x)
 
-static inline void _ternfs_fetch_block_with_crc_req_put_offset(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_crc* prev, struct ternfs_fetch_block_with_crc_req_offset* next, u32 x) {
+static inline void _ternfs_fetch_block_with_crc_req_put_offset(struct ternfs_bincode_put_ctx* ctx, struct ternfs_fetch_block_with_crc_req_block_crc_unused* prev, struct ternfs_fetch_block_with_crc_req_offset* next, u32 x) {
     next = NULL;
     BUG_ON(ctx->end - ctx->cursor < 4);
     put_unaligned_le32(x, ctx->cursor);

--- a/kmod/block.c
+++ b/kmod/block.c
@@ -1132,9 +1132,9 @@ static int fetch_block_pages_with_crc_write_req(struct block_socket* socket, str
             .end = req_msg_buf + sizeof(req_msg_buf),
         };
         ternfs_fetch_block_with_crc_req_put_start(&ctx, start);
-        ternfs_fetch_block_with_crc_req_put_file_id(&ctx, start, req_file_id, req->file_id);
+        ternfs_fetch_block_with_crc_req_put_file_id_unused(&ctx, start, req_file_id, 0);
         ternfs_fetch_block_with_crc_req_put_block_id(&ctx, req_file_id, req_block_id, req->block_id);
-        ternfs_fetch_block_with_crc_req_put_block_crc(&ctx, req_block_id, req_block_crc, req->block_crc);
+        ternfs_fetch_block_with_crc_req_put_block_crc_unused(&ctx, req_block_id, req_block_crc, 0);
         ternfs_fetch_block_with_crc_req_put_offset(&ctx, req_block_crc, req_offset, req->offset);
         ternfs_fetch_block_with_crc_req_put_count(&ctx, req_offset, req_count, req->count);
         ternfs_fetch_block_with_crc_req_put_end(ctx, req_count, end);


### PR DESCRIPTION
This is in preparation with a deeper refactor of reading from Go in general. The big difference that we have now which we did not have before is that we now have CRCs for every single page.