### PR TITLE
registry: flag for better dynamic port handling

### DIFF
--- a/cpp/registry/Registerer.cpp
+++ b/cpp/registry/Registerer.cpp
@@ -89,7 +89,7 @@ bool Registerer::_updateReplicas(const std::vector<FullRegistryInfo> &allReplica
 
     size_t knownReplicas{0};
     for (auto &replica : localReplicas) {
-        if (replica.addrs[0].port != 0) {
+        if (replica.addrs[0].port != 0 || replica.addrs[1].port) {
             ++knownReplicas;
         }
     }

--- a/cpp/registry/Registry.cpp
+++ b/cpp/registry/Registry.cpp
@@ -508,7 +508,7 @@ private:
             auto &allRegiResp = resp.resp.setAllRegistryReplicas();
             for (uint8_t i = 0; i < _replicas.size(); ++i) {
                 auto &addrs = _replicas[i];
-                if (addrs.addrs[0].ip.data[0] == 0) {
+                if (addrs.addrs[0].port == 0 && addrs.addrs[1].port == 0) {
                     continue;
                 }
                 auto &replica = allRegiResp.replicas.els.emplace_back();

--- a/cpp/registry/RegistryCommon.hpp
+++ b/cpp/registry/RegistryCommon.hpp
@@ -27,6 +27,7 @@ struct RegistryOptions {
     uint8_t alertAfterUnavailableFailureDomains = 3;
     uint32_t maxFailureDomainsPerShard = 28;
     Duration writableBlockServiceUpdateInterval = 30_mins;
+    bool usingDynamicPorts = false;
 };
 
 struct RegistryState;

--- a/cpp/registry/ternregistry.cpp
+++ b/cpp/registry/ternregistry.cpp
@@ -61,6 +61,11 @@ static bool parseRegistryOptions(CommandLineArgs& args, RegistryOptions& options
             options.writableBlockServiceUpdateInterval = parseDuration(args.next());
             continue;
         }
+        if (arg == "-using-dynamic-ports") {
+            args.next();
+            options.usingDynamicPorts = true;
+            continue;
+        }
         fprintf(stderr, "unknown argument %s\n", args.peekArg().c_str());
         return false;
     }
@@ -93,6 +98,8 @@ static void printRegistryOptionsUsage() {
     fprintf(stderr, "       Maximum number of block services to assign to a shard for writting at any given time. Default is 28\n");
     fprintf(stderr, " -writable-block-service-update-interval\n");
     fprintf(stderr, "       Maximum interval at which to change writable services assigned to shards. Default 30 min\n");
+    fprintf(stderr, " -using-dynamic-ports\n");
+    fprintf(stderr, "       Inform registry services are using dynamic ports. Registry will wipe port information on startup to speed up bootstrap\n");
 }
 
 static bool validateRegistryOptions(const RegistryOptions& options) {

--- a/go/core/managedprocess/managedprocess.go
+++ b/go/core/managedprocess/managedprocess.go
@@ -432,6 +432,7 @@ type RegistryOpts struct {
 	Addr1           string
 	Addr2           string
 	LogsDBFlags     []string
+	UsingDynamicPorts bool
 }
 
 func (procs *ManagedProcesses) StartRegistry(ll *log.Logger, opts *RegistryOpts) {
@@ -460,6 +461,9 @@ func (procs *ManagedProcesses) StartRegistry(ll *log.Logger, opts *RegistryOpts)
 	}
 	if opts.LogsDBFlags != nil {
 		args = append(args, opts.LogsDBFlags...)
+	}
+	if opts.UsingDynamicPorts {
+		args = append(args, "-using-dynamic-ports")
 	}
 	procs.Start(ll, &ManagedProcessArgs{
 		Name:            "registry",

--- a/go/ternrun/ternrun.go
+++ b/go/ternrun/ternrun.go
@@ -155,12 +155,6 @@ func main() {
 			if r == 0 {
 				dir = path.Join(*dataDir, "registry")
 			}
-			if _, err := os.Stat(dir); !os.IsNotExist(err) {
-				fmt.Printf("Wiping registry replica %d to speed up bootstrap\n", r)
-				if err := os.RemoveAll(dir); err != nil {
-					panic(fmt.Errorf("failed to remove directory %s: %v", dir, err))
-				}
-			}
 			
 			opts := managedprocess.RegistryOpts{
 				Exe:             cppExes.RegistryExe,
@@ -170,6 +164,7 @@ func main() {
 				Replica:         msgs.ReplicaId(r),
 				Xmon:            *xmon,
 				Addr1:           "127.0.0.1:0",
+				UsingDynamicPorts: true,
 			}
 			if r == 0 {
 				if *leaderOnly {

--- a/go/terntests/terntests.go
+++ b/go/terntests/terntests.go
@@ -783,7 +783,7 @@ func killBlockServices(
 	rand := wyhash.New(uint64(time.Now().UnixNano()))
 	go func() {
 		defer func() { lrecover.HandleRecoverChan(log, terminateChan, recover()) }()
-		 lc := net.ListenConfig{
+		lc := net.ListenConfig{
 			Control: func(network, address string, c syscall.RawConn) error {
 				var operr error
 				err := c.Control(func(fd uintptr) {
@@ -795,7 +795,7 @@ func killBlockServices(
 				return operr
 			},
 		}
-		var reservedPorts [2]net.Listener 
+		var reservedPorts [2]net.Listener
 		for {
 			// pick and kill the victim
 			pause.Lock()
@@ -815,12 +815,12 @@ func killBlockServices(
 						procs.Kill(procId, syscall.SIGKILL)
 						if ports._1 != 0 {
 							if port1Listener, err := lc.Listen(context.Background(), "tcp4", fmt.Sprintf("127.0.0.1:%d", ports._1)); err == nil {
-								reservedPorts[0] = port1Listener	
+								reservedPorts[0] = port1Listener
 							}
 						}
 						if ports._2 != 0 {
 							if port2Listener, err := lc.Listen(context.Background(), "tcp4", fmt.Sprintf("127.0.0.1:%d", ports._2)); err == nil {
-								reservedPorts[1] = port2Listener	
+								reservedPorts[1] = port2Listener
 							}
 						}
 						break
@@ -1126,11 +1126,12 @@ func main() {
 				dir = path.Join(*dataDir, "registry")
 			}
 			opts := managedprocess.RegistryOpts{
-				Exe:             cppExes.RegistryExe,
-				LogLevel:        level,
-				Dir:             dir,
-				RegistryAddress: registryAddress,
-				Replica:         msgs.ReplicaId(r),
+				Exe:               cppExes.RegistryExe,
+				LogLevel:          level,
+				Dir:               dir,
+				RegistryAddress:   registryAddress,
+				Replica:           msgs.ReplicaId(r),
+				UsingDynamicPorts: true,
 			}
 			if r == 0 {
 				if *leaderOnly {


### PR DESCRIPTION
In case of full shutdown/startup and usage of dynamic ports it is possible replicas get out of date address information.
Since they think there is enough replicas to form a quorum they will not try to refetch address information immediately but after some delay.
This flag -using-dynamic-ports informs registry to wipe ports on startup. As empty ports are not considered valid addresses replicas will refetch information quickly.

Note that in case of production rolling restart this is not a problem as replica information changes slowly.