### PR TITLE
Use mimalloc in release and alpine builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ Will build all the artifacts apart from the Kernel module. The output binaries w
 
 There's also `./build.sh ubuntu` which will do the same but in a Ubuntu container, and `./build.sh release` which will build outside docker, which means that you'll have to install some dependencies in the host machine. Both of these build options will have glibc as the only dynamically linked dependency.
 
-We use the Ubuntu-built version in production, mostly due to jemalloc not playing well with Alpine. It should be easy to produce a performant Alpine build, we just never had the need so far.
-
 ## Testing
 
 ```

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -50,10 +50,9 @@ set(SANITIZE_OPTIONS "-fsanitize=undefined,address,integer,function;-fno-sanitiz
 add_compile_options("$<$<CONFIG:sanitized>:${SANITIZE_OPTIONS}>")
 add_link_options("$<$<CONFIG:sanitized>:${SANITIZE_OPTIONS}>")
 
-# we only use jemalloc in release builds, alpine doesn't seem to
-# like jemalloc very much, and sanitizer etc works better without it
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "release")
-    set(TERNFS_JEMALLOC_LIBS "jemalloc")
+# we only use mimalloc in release builds, sanitizer etc works better without it
+if("${CMAKE_BUILD_TYPE}" MATCHES "^(release|alpine)$")
+    set(TERNFS_MIMALLOC_LIBS "mimalloc")
 endif()
 
 include(thirdparty.cmake)

--- a/cpp/cdc/CMakeLists.txt
+++ b/cpp/cdc/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(cdc CDC.cpp CDC.hpp CDCDB.cpp CDCDB.hpp CDCDBData.hpp)
 target_link_libraries(cdc PRIVATE core)
 
 add_executable(terncdc terncdc.cpp)
-target_link_libraries(terncdc PRIVATE core shard cdc ${TERNFS_JEMALLOC_LIBS})
+target_link_libraries(terncdc PRIVATE core shard cdc ${TERNFS_MIMALLOC_LIBS})

--- a/cpp/dbtools/CMakeLists.txt
+++ b/cpp/dbtools/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(sharddbtools ShardDBTools.hpp ShardDBTools.cpp LogsDBTools.hpp LogsD
 target_link_libraries(sharddbtools PRIVATE core shard cdc)
 
 add_executable(terndbtools terndbtools.cpp)
-target_link_libraries(terndbtools PRIVATE core shard sharddbtools ${TERNFS_JEMALLOC_LIBS})
+target_link_libraries(terndbtools PRIVATE core shard sharddbtools ${TERNFS_MIMALLOC_LIBS})

--- a/cpp/registry/CMakeLists.txt
+++ b/cpp/registry/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(registry Registry.hpp Registry.cpp RegistryDB.hpp RegistryDB.cpp
 target_link_libraries(registry PRIVATE core)
 
 add_executable(ternregistry ternregistry.cpp)
-target_link_libraries(ternregistry PRIVATE core registry crc32c ${TERNFS_JEMALLOC_LIBS})
+target_link_libraries(ternregistry PRIVATE core registry crc32c ${TERNFS_MIMALLOC_LIBS})

--- a/cpp/shard/CMakeLists.txt
+++ b/cpp/shard/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(shard Shard.cpp Shard.hpp ShardDB.cpp ShardDB.hpp ShardDBData.cpp Sh
 target_link_libraries(shard PRIVATE core)
 
 add_executable(ternshard ternshard.cpp)
-target_link_libraries(ternshard PRIVATE core shard crc32c ${TERNFS_JEMALLOC_LIBS})
+target_link_libraries(ternshard PRIVATE core shard crc32c ${TERNFS_MIMALLOC_LIBS})


### PR DESCRIPTION
This should make the alpine build usable in production.