### PR TITLE
reduce false sharing in LogsDBStats

### DIFF
--- a/cpp/core/LogsDB.hpp
+++ b/cpp/core/LogsDB.hpp
@@ -70,22 +70,31 @@ struct LogsDBResponse {
 std::ostream& operator<<(std::ostream& out, const LogsDBResponse& entry);
 
 struct LogsDBStats {
+    alignas(64)
+    std::atomic<bool> isLeader{false};
     std::atomic<Duration> idleTime{0};
     std::atomic<Duration> processingTime{0};
-    std::atomic<Duration> leaderLastActive{0};
-    std::atomic<double> appendWindow{0};
-    std::atomic<double> entriesReleased{0};
-    std::atomic<double> followerLag{0};
-    std::atomic<double> readerLag{0};
-    std::atomic<double> catchupWindow{0};
-    std::atomic<double> entriesRead{0};
     std::atomic<double> requestsReceived{0};
     std::atomic<double> responsesReceived{0};
+    std::atomic<double> appendWindow{0};
+
+    alignas(64)
     std::atomic<double> requestsSent{0};
     std::atomic<double> responsesSent{0};
     std::atomic<double> requestsTimedOut{0};
+
+    alignas(64)
+    std::atomic<double> entriesRead{0};
+    std::atomic<double> readerLag{0};
+
+    alignas(64)
+    std::atomic<double> followerLag{0};
+    std::atomic<double> catchupWindow{0};
+
+    alignas(64)
+    std::atomic<Duration> leaderLastActive{0};
     std::atomic<uint64_t> currentEpoch{0};
-    std::atomic<bool> isLeader{false};
+    std::atomic<double> entriesReleased{0};
 };
 
 class LogsDBImpl;


### PR DESCRIPTION
these fields are all atomic so the accesses are safe, but different threads end up stepping on each other's toes when accessing different fields

this adds padding and groups together the fields accessed at the same time

- the first group is the hot path, which are updated together in the main event loop
- then there's the request/response management group
- then the reader group
- then the catchup group
- and finally there's a misc metadata group, which are touched independently at different times