### PR TITLE
Fix s3fs-fuse mkdir creates a regular file instead of a directory

### DIFF
--- a/go/s3/s3.go
+++ b/go/s3/s3.go
@@ -140,6 +140,17 @@ func (p *objectPath) dir() *objectPath {
 	return d
 }
 
+// isDirectoryContentType reports whether a Content-Type marks an object as a
+// directory. s3fs sends "application/x-directory" for mkdir; "httpd/unix-directory"
+// is the Apache/Nextcloud convention.
+func isDirectoryContentType(contentType string) bool {
+	if i := strings.IndexByte(contentType, ';'); i >= 0 {
+		contentType = contentType[:i]
+	}
+	contentType = strings.TrimSpace(contentType)
+	return contentType == "application/x-directory" || contentType == "httpd/unix-directory"
+}
+
 func parseObjectPath(str string) *objectPath {
 	p := &objectPath{
 		segments:    []string{},
@@ -494,7 +505,11 @@ func (s *S3Server) handleGetObject(ctx context.Context, w http.ResponseWriter, r
 	w.Header().Set("ETag", FileEtag(dentry.TargetId))
 	w.Header().Set("Last-Modified", lastModified.Time().Format(http.TimeFormat))
 	w.Header().Set("Accept-Ranges", "bytes")
-	w.Header().Set("Content-Type", "application/octet-stream")
+	if dentry.TargetId.Type() == msgs.DIRECTORY {
+		w.Header().Set("Content-Type", "application/x-directory")
+	} else {
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
 
 	if rangeHeader == "" {
 		w.Header().Set("Content-Length", strconv.FormatInt(int64(size), 10))
@@ -714,10 +729,22 @@ func (s *S3Server) handlePutObject(ctx context.Context, w http.ResponseWriter, r
 
 	var inode msgs.InodeId
 	basename := path.basename()
-	if path.isDirectory {
+	if path.isDirectory || isDirectoryContentType(r.Header.Get("Content-Type")) {
 		resp := &msgs.MakeDirectoryResp{}
 		if err := s.c.CDCRequest(s.log, &msgs.MakeDirectoryReq{OwnerId: ownerId, Name: basename}, resp); err != nil {
-			return fmt.Errorf("failed to make directory: %w", err)
+			// mkdir must be idempotent: clients (e.g. s3fs) re-PUT directory
+			// markers, and stat refreshes can race. If the name already exists
+			// as a directory, treat it as success.
+			if errors.Is(err, msgs.CANNOT_OVERRIDE_NAME) {
+				lookupResp := &msgs.LookupResp{}
+				if lookupErr := s.c.ShardRequest(s.log, ownerId.Shard(), &msgs.LookupReq{DirId: ownerId, Name: basename}, lookupResp); lookupErr == nil && lookupResp.TargetId.Type() == msgs.DIRECTORY {
+					inode = lookupResp.TargetId
+				} else {
+					return fmt.Errorf("failed to make directory: %w", err)
+				}
+			} else {
+				return fmt.Errorf("failed to make directory: %w", err)
+			}
 		} else {
 			inode = resp.Id
 		}

--- a/go/s3/s3_test.go
+++ b/go/s3/s3_test.go
@@ -1,0 +1,44 @@
+// Copyright 2025 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package s3
+
+import (
+	"testing"
+	"xtx/ternfs/core/assert"
+)
+
+func TestIsDirectoryContentType(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		// The conventions we treat as directory markers.
+		{"s3fs x-directory", "application/x-directory", true},
+		{"apache unix-directory", "httpd/unix-directory", true},
+
+		// Parameters (charset etc.) must be stripped before comparison.
+		{"x-directory with charset", "application/x-directory; charset=utf-8", true},
+		{"x-directory with trailing param", "application/x-directory;", true},
+		{"unix-directory with param and spaces", "httpd/unix-directory ; q=1", true},
+		{"surrounding whitespace", "  application/x-directory  ", true},
+
+		// Regular object content types are not directories.
+		{"octet-stream", "application/octet-stream", false},
+		{"text plain", "text/plain", false},
+		{"text plain with charset", "text/plain; charset=utf-8", false},
+		{"empty", "", false},
+
+		// Match is exact on the media type, not a prefix/substring.
+		{"superstring", "application/x-directory-ish", false},
+		{"substring", "x-directory", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isDirectoryContentType(tc.contentType))
+		})
+	}
+}


### PR DESCRIPTION
## Bug report: s3fs-fuse `mkdir` (PUT directory marker) creates a file, not a directory

  ### Symptom
  Mounting TernFS via s3fs-fuse, `mkdir` creates a regular **file** instead of a
  directory. Read/write/delete/list all work; only directory creation is broken.

  ### Evidence
  s3fs sends a textbook directory marker on `mkdir` (captured via `curldbg`):
```
  PUT //Temp/test_dir2/        <- trailing slash
  Content-Type: application/x-directory
  Content-Length: 0
  -> 200 OK
```
  But the created inode is a FILE. The returned ETag is the TernFS InodeId, whose
  top 2 bits encode the type (`msgs/msgs.go`: 1=DIRECTORY, 2=FILE, 3=SYMLINK):
```
  ETag 4611686388178858929  ->  (id >> 61) & 0x3 = 2 = FILE
```
  Downstream readback is consistent with a file: `HEAD` returns
  `Content-Type: text/plain`, and `list-objects-v2` returns the key under
  `Contents` (not `CommonPrefixes`).

  ### Root cause
  `handlePutObject` decided file-vs-directory solely from the trailing slash
  (`path.isDirectory`, set in `parseObjectPath`). When only the
  `application/x-directory` content-type is present — e.g. if a fronting
  gateway/proxy normalizes the trailing slash off the key — the request falls
  through to `ConstructFile` and a file is created.

  ### Fix (this PR)
  - PUT creates a directory when the key ends in `/` or
    `Content-Type` is `application/x-directory` / `httpd/unix-directory`.
  - `MakeDirectory` is idempotent: an existing directory of the same name
    (`CANNOT_OVERRIDE_NAME`) is treated as success — s3fs re-PUTs markers and
    stat refreshes race.
  - GET/HEAD reports `Content-Type: application/x-directory` for directory
    inodes so clients classify the type on readback.