### PR TITLE
kmod: fix span refcount leaks around ternfs_unlink_span

### DIFF
--- a/kmod/file.c
+++ b/kmod/file.c
@@ -1369,7 +1369,6 @@ retry:
 
     if (span->start%PAGE_SIZE != 0) {
         ternfs_error("file=%016lx offset=%llu span start not a multiple of page size", enode->inode.i_ino, span->start);
-        span = NULL;
         err = -EIO;
         goto out;
     }

--- a/kmod/file.c
+++ b/kmod/file.c
@@ -1414,8 +1414,9 @@ retry:
             }
             if ((end_ts.tv_sec - last_span_refresh_ts.tv_sec) > ternfs_file_io_retry_refresh_span_interval_sec) {
                 ternfs_debug("file=%016lx refreshing span at offset=%lld", enode->inode.i_ino, off);
+                // Evict the stale span from the cache. We keep our own
+                // reference: the retry below puts it before fetching again.
                 ternfs_unlink_span(&enode->file.spans, span);
-                span = NULL; // unlink already reduced refcount
                 last_span_refresh_ts = end_ts;
             }
             goto retry;

--- a/kmod/file.c
+++ b/kmod/file.c
@@ -1518,8 +1518,10 @@ static void file_readahead(struct readahead_control *rac)
         pages_allocated++;
     }
 
-    if (pages_allocated == 0)
-        return;
+    if (pages_allocated == 0) {
+        err = -ENOMEM;
+        goto out_err;
+    }
 
     // Process based on span type
     if (span->storage_class == TERNFS_INLINE_STORAGE) {

--- a/kmod/span.c
+++ b/kmod/span.c
@@ -969,6 +969,7 @@ retry:
             // evict expired span
             if (unlikely(fetched_at - span->fetched_at > ternfs_span_cache_retention_jiffies && span->storage_class != TERNFS_INLINE_STORAGE)) {
                 ternfs_unlink_span(spans, span);
+                ternfs_put_span(span); // drop the reference we took above
                 span = NULL;
             } else {
                 return span;
@@ -1023,13 +1024,18 @@ retry:
 #undef GET_SPAN_EXIT
 }
 
+// Removes the span from the cache, dropping the reference the cache itself
+// held. The caller's own reference is untouched: it is up to the caller to
+// ternfs_put_span() it once it is done with the span.
 void ternfs_unlink_span(struct ternfs_file_spans* spans, struct ternfs_span* span) {
     down_write(&spans->__lock);
+    // Somebody else might have unlinked it already, in which case the cache's
+    // reference is already gone and we must not drop it twice.
     if (likely(!RB_EMPTY_NODE(&span->node))) {
         rb_erase(&span->node, &spans->__spans);
         RB_CLEAR_NODE(&span->node);
+        ternfs_put_span(span);
     }
-    ternfs_put_span(span);
     up_write(&spans->__lock);
 }
 

--- a/kmod/span.c
+++ b/kmod/span.c
@@ -1034,6 +1034,7 @@ void ternfs_unlink_span(struct ternfs_file_spans* spans, struct ternfs_span* spa
     if (likely(!RB_EMPTY_NODE(&span->node))) {
         rb_erase(&span->node, &spans->__spans);
         RB_CLEAR_NODE(&span->node);
+        BUG_ON(atomic_read(&span->refcount) <= 1);
         ternfs_put_span(span);
     }
     up_write(&spans->__lock);


### PR DESCRIPTION
# Summary

This PR is three commits that fix different bugs in and around `ternfs_unlink_span()`. They are in one PR merely because stacked changes in github suck.

##  Fix 1: Clarify contract of `ternfs_unlink_span()`

`ternfs_unlink_span()` [here](https://github.com/XTXMarkets/ternfs/blob/aefda7b82e2c43f85f21fdfc6168e43004f062dd/kmod/span.c#L1026) dropped a single reference while both of its callers held
two: one owned by the span cache (the rb-tree) and one owned by the caller. The
two callers disagreed about which one that put covered.
    
`ternfs_get_span()`  [here](https://github.com/XTXMarkets/ternfs/blob/aefda7b82e2c43f85f21fdfc6168e43004f062dd/kmod/span.c#L965)expected its own reference to survive. It looks the span up
and takes a reference under` __lock`:

```c
  struct ternfs_span* span = lookup_span(&spans->__spans, offset);
  if (likely(span != NULL)) {
    atomic_inc(&span->refcount);
  }
```

and then, if the span has expired, unlinks it and sets span = NULL. Nothing in
that block consumes the reference it just took, and it cannot have expected
`ternfs_unlink_span()` to consume it: that would free the object while span was
still a live pointer. So the caller's reference was simply dropped on the floor.
    
Meanwhile, `file_readpage()`  [here](https://github.com/XTXMarkets/ternfs/blob/aefda7b82e2c43f85f21fdfc6168e43004f062dd/kmod/file.c#L1418) expected the opposite. Its

```c
                span = NULL; // unlink already reduced refcount
```

cleared the pointer so that the puts at the retry label and at out: would not
double free. That is self-consistent, but it leaks the *cache's* reference
instead, and since the span is off the rb-tree by then `ternfs_free_file_spans()`
cannot reclaim it at inode eviction either.
    
This PR gives `ternfs_unlink_span()` one unambiguous contract: it drops only the reference
held by the span cache, and the caller keeps its own. Move the put inside the
`RB_EMPTY_NODE` check while we are here -- the unconditional put was also a latent
double put, since a thread which lost a race to unlink the same span skipped the
rb_erase() but still dropped a reference it did not own. Then fix the callers to
match: `ternfs_get_span()` puts its own reference, and `file_readpage()` keeps its
pointer so the put at the retry label runs.

## Fix 2: don't leak the span on a misaligned span in file_readpage

Simple error path fix

## Fix 3: kmod: don't leak the span when readahead can't allocate pages

Simple error path fix
