### PR TITLE
 kmod: fix span leak for symlink inodes

### DIFF
--- a/go/terntests/dirseek.go
+++ b/go/terntests/dirseek.go
@@ -162,8 +162,21 @@ func dirSeek(fd C.int, off C.long, whence C.int) (C.long, error) {
 	return off, nil
 }
 
+// Symlink targets are stored inline in the span when they're short enough
+// (`struct ternfs_inline_span` holds up to 255 bytes), and in a block span
+// otherwise. We want both, so that reading the links below exercises both
+// span caches.
+func dirSeekSymlinkTarget(mountPoint string, i int) string {
+	if i%2 == 0 {
+		return mountPoint // short: ends up inline
+	}
+	// long: forced out of the inline span and into a block span
+	return path.Join(mountPoint, fmt.Sprintf("%0*d", 300, i))
+}
+
 func dirSeekTest(log *log.Logger, registryAddress string, mountPoint string, numPaths int) {
 	log.Info("creating %v paths", numPaths)
+	symlinkTargets := map[string]string{}
 	for i := 0; i < numPaths; i++ {
 		path := path.Join(mountPoint, fmt.Sprintf("%v", i))
 		if i%10 == 0 { // dirs, not too many since they're more expensive to create
@@ -171,9 +184,11 @@ func dirSeekTest(log *log.Logger, registryAddress string, mountPoint string, num
 				panic(err)
 			}
 		} else if i%3 == 0 {
-			if err := os.Symlink(mountPoint, path); err != nil {
+			target := dirSeekSymlinkTarget(mountPoint, i)
+			if err := os.Symlink(target, path); err != nil {
 				panic(err)
 			}
+			symlinkTargets[path] = target
 		} else {
 			f, err := os.Create(path)
 			if err != nil {
@@ -184,6 +199,21 @@ func dirSeekTest(log *log.Logger, registryAddress string, mountPoint string, num
 			}
 		}
 	}
+	// Read the symlinks back. Besides checking that we get the target we wrote,
+	// this makes sure we actually go through the symlink read path: it fetches
+	// the target through the span cache, and the spans it caches are attached
+	// to the symlink inode until the inode is evicted.
+	log.Info("reading %v symlinks", len(symlinkTargets))
+	for linkPath, target := range symlinkTargets {
+		got, err := os.Readlink(linkPath)
+		if err != nil {
+			panic(fmt.Errorf("readlink %v: %w", linkPath, err))
+		}
+		if got != target {
+			panic(fmt.Errorf("readlink %v: expected target %q, got %q", linkPath, target, got))
+		}
+	}
+
 	// open root dir
 	dirFd, err := openDir(mountPoint)
 	if err != nil {

--- a/kmod/inode.c
+++ b/kmod/inode.c
@@ -61,7 +61,7 @@ void ternfs_inode_evict(struct inode* inode) {
     ternfs_debug("evict enode=%p", enode);
     if (S_ISDIR(inode->i_mode)) {
         ternfs_dir_drop_cache(enode);
-    } else if (S_ISREG(inode->i_mode)) {
+    } else if (S_ISREG(inode->i_mode) || S_ISLNK(inode->i_mode)) {
         ternfs_free_file_spans(&enode->file.spans);
     }
     truncate_inode_pages(&inode->i_data, 0);


### PR DESCRIPTION
## Failure

I tried to unload the `ternfs_client` kmod on a host that had been in production for 6 months.

I saw a ton of these errors:

```
Jul 30 10:44:05 kernel: =============================================================================
  Jul 30 10:44:05 kernel: BUG ternfs_block_span_cache (Tainted: G    B   W  OEL    ): Objects remaining in ternfs_block_span_cache on __kmem_cache_shutdown()
  Jul 30 10:44:05 kernel: -----------------------------------------------------------------------------
  Jul 30 10:44:05 kernel: Slab 0x00000000d4cff219 objects=63 used=2 fp=0x00000000c3e8a671 flags=0x17ffffc0000a40(workingset|slab|head|node=0|zone=2|lastcpupid=0x1fffff)
  Jul 30 10:44:05 kernel: CPU: 22 PID: 2162615 Comm: rmmod Tainted: G    B   W  OEL     6.8.0-31-generic #31-Ubuntu
...

```

Rolling up the numbers through the slab hierarchy:

```
  ┌─────────────────────────────────────┬────────────┬──────────────────┬─────────────┬─────────┐
  │                                     │ block_span │ fetch_span_pages │ inline_span │  total  │
  ├─────────────────────────────────────┼────────────┼──────────────────┼─────────────┼─────────┤
  │ kmem_cache_destroy calls            │ 1          │ 1                │ 1           │ 3       │
  ├─────────────────────────────────────┼────────────┼──────────────────┼─────────────┼─────────┤
  │ BUG ... Objects remaining blocks    │ 5,916      │ 122              │ 87          │ 6,125   │
  ├─────────────────────────────────────┼────────────┼──────────────────┼─────────────┼─────────┤
  │ Object 0x... lines = leaked objects │ 235,517    │ 4,339            │ 416         │ 240,272 │
  ├─────────────────────────────────────┼────────────┼──────────────────┼─────────────┼─────────┤
  │ objects per slab (capacity)         │ 63         │ 47               │ 51          │         │
  └─────────────────────────────────────┴────────────┴──────────────────┴─────────────┴─────────┘
```

 The counts are large but not enormous for six months of uptime, and there were no eggsfs driver errors anywhere in the log. No read failures, no timeouts, no retries. That ruled out the error paths and pointed at something leaking on an ordinary success path that just isn't hit very often. The `566:1` ratio of `block_span` to `fetch_span_pages` objects narrowed it further: `fetch_span_pages_state` is only allocated when a block span actually needs fetching, so something was caching spans without going through a normal file read.

This PR fixes one such identified leak, and the accompanying test reproduces in a very similar way.

## The bug

`struct ternfs_inode` holds file and dir in a union [here](https://github.com/XTXMarkets/ternfs/blob/855fcfb7a812f2ce0648f06ed56dec8f8ba839f4/kmod/inode.h#L111), so whichever arm we initialise is the one we have to tear down. `ternfs_get_inode()` initialises file.spans for regular files and symlinks [here](https://github.com/XTXMarkets/ternfs/blob/855fcfb7a812f2ce0648f06ed56dec8f8ba839f4/kmod/inode.c#L792), but `ternfs_inode_evict()` only freed them for regular files [here](https://github.com/XTXMarkets/ternfs/blob/855fcfb7a812f2ce0648f06ed56dec8f8ba839f4/kmod/inode.c#L64). Symlinks fell through and their spans were never released.

The fix is trivial.

## Testing

`dirSeekTest()` already created symlinks but only ever read the directory they lived in, so `ternfs_get_link()` never ran and the leak was invisible. The test commit reads the links back and checks the targets. Targets alternate between short and 300+ bytes: `compute_span_parameters()` stores anything under 256 bytes inline and sends longer spans to block storage, so both span caches see traffic.

The dir seek test was already in `kmod/ci.sh` default filter list, so the new coverage runs without any CI config change. `ci.sh` already captures `dmesg` for the whole run and fails the build on any `BUG` or `WARNING`.

I pushed just HEAD^ to CI and captured this failure: 

https://github.com/XTXMarkets/ternfs/actions/runs/30617853232/job/91115377155?pr=134

This shows the expected bug signature
1. The signature is the one the fix targets. BUG ... Objects remaining in `ternfs_<x>_span_cache` on `__kmem_cache_shutdown()`
2. Both span caches leak, which is what the test was built to provoke: 49 objects in `ternfs_inline_span_cache` and 59 in `ternfs_block_span_cache`. The total used= across the 8 slab reports is 108, matching the per-cache object counts.
3. `dirSeekTest` creates 300 symlinks in a -short run and 108 spans leaked. The leak happens at inode eviction, so the count depends on how many symlink inodes are actually evicted during the run rather than on how many were created.
