### PR TITLE
terncli tag-files: Add dangling symlink infrastructure

### DIFF
--- a/go/terncli/tagfiles.go
+++ b/go/terncli/tagfiles.go
@@ -139,6 +139,9 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 			}
 			return nil
 		}
+		if !fileRulesApplyTo(id) {
+			return nil
+		}
 		if !owned || !current {
 			return nil
 		}
@@ -222,4 +225,8 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 		return walkErr
 	}
 	return closeErr
+}
+
+func fileRulesApplyTo(id msgs.InodeId) bool {
+	return id.Type() == msgs.FILE
 }

--- a/go/terncli/tagfiles.go
+++ b/go/terncli/tagfiles.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 	"xtx/ternfs/client"
+	"xtx/ternfs/core/bufpool"
 	"xtx/ternfs/core/log"
 	"xtx/ternfs/msgs"
 )
@@ -28,15 +29,18 @@ type tagFilesParams struct {
 }
 
 type tagFilesStats struct {
-	files          atomic.Uint64
-	dirs           atomic.Uint64
-	preskipped     atomic.Uint64
-	dirsEmptyCheck atomic.Uint64
-	tags           []string
-	rowsByTag      map[string]*atomic.Uint64
-	bytesByTag     map[string]*atomic.Uint64
-	statErrors     atomic.Uint64
-	matchErrors    atomic.Uint64
+	files           atomic.Uint64
+	dirs            atomic.Uint64
+	preskipped      atomic.Uint64
+	dirsEmptyCheck  atomic.Uint64
+	tags            []string
+	rowsByTag       map[string]*atomic.Uint64
+	bytesByTag      map[string]*atomic.Uint64
+	statErrors      atomic.Uint64
+	matchErrors     atomic.Uint64
+	symlinks        atomic.Uint64
+	matchedSymlinks atomic.Uint64
+	symlinkErrors   atomic.Uint64
 }
 
 func newTagFilesStats(rules []*Rule) *tagFilesStats {
@@ -66,14 +70,19 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 	}
 	fileRules := make([]*Rule, 0, len(rules))
 	dirRules := make([]*Rule, 0, len(rules))
+	symlinkRules := make([]*Rule, 0, len(rules))
 	for _, r := range rules {
-		if r.AppliesTo == "directory" {
+		switch r.AppliesTo {
+		case "directory":
 			dirRules = append(dirRules, r)
-		} else {
+		case "symlink":
+			symlinkRules = append(symlinkRules, r)
+		default:
 			fileRules = append(fileRules, r)
 		}
 	}
-	l.Info("loaded %d rules (%d file, %d directory)", len(rules), len(fileRules), len(dirRules))
+	l.Info("loaded %d rules (%d file, %d directory, %d symlink)",
+		len(rules), len(fileRules), len(dirRules), len(symlinkRules))
 
 	stats := newTagFilesStats(rules)
 
@@ -87,6 +96,56 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 
 	now := msgs.Now()
 	startedAt := time.Now()
+
+	var symlinkFS symlinkFilesystem
+	if len(symlinkRules) > 0 {
+		symlinkFS = &ternSymlinkFilesystem{
+			client:  c,
+			log:     l,
+			bufPool: bufpool.NewBufPool(),
+		}
+	}
+
+	processSymlink := func(job symlinkJob) {
+		if symlinkFS == nil {
+			return
+		}
+		resp := msgs.StatFileResp{}
+		if err := c.ShardRequest(l, job.id.Shard(), &msgs.StatFileReq{Id: job.id}, &resp); err != nil {
+			l.ErrorNoAlert("stat symlink %s: %v", job.fullPath, err)
+			stats.symlinkErrors.Add(1)
+			return
+		}
+		fired, err := FirstSymlinkMatch(
+			symlinkRules,
+			job.fullPath,
+			resp.Size,
+			resp.Atime,
+			resp.Mtime,
+			now,
+			func() (bool, error) {
+				return symlinkIsDangling(symlinkFS, job.fullPath, job.id)
+			},
+		)
+		if err != nil {
+			l.ErrorNoAlert("resolve symlink %s: %v", job.fullPath, err)
+			stats.symlinkErrors.Add(1)
+			return
+		}
+		if fired == nil {
+			return
+		}
+		stats.matchedSymlinks.Add(1)
+		stats.rowsByTag[fired.Tag].Add(1)
+		stats.bytesByTag[fired.Tag].Add(resp.Size)
+		if p.dryRun {
+			return
+		}
+		if err := bw.AppendRow(fired.Tag, uint8(job.id.Shard()), symlinkRow(job, resp, fired)); err != nil {
+			l.ErrorNoAlert("append symlink %s: %v", job.fullPath, err)
+			stats.matchErrors.Add(1)
+		}
+	}
 
 	cb := func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {
 		if id.Type() == msgs.DIRECTORY {
@@ -136,6 +195,16 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 			if err := bw.AppendRow(fired.Tag, uint8(id.Shard()), row); err != nil {
 				l.ErrorNoAlert("append row %s tag=%s: %v", fullPath, fired.Tag, err)
 				stats.matchErrors.Add(1)
+			}
+			return nil
+		}
+		if id.Type() == msgs.SYMLINK {
+			if symlinkFS != nil && owned && current {
+				stats.symlinks.Add(1)
+				fullPath := path.Join(parentPath, name)
+				if anyPathMatches(symlinkRules, fullPath) {
+					processSymlink(symlinkJob{id: id, fullPath: fullPath})
+				}
 			}
 			return nil
 		}
@@ -214,6 +283,10 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 	rate := float64(files) / elapsed.Seconds()
 	l.Info("tag-files done in %s: %d files visited (%d dirs), %.0f files/s, %d stat-preskipped, %d dir-empty-checks, %d stat errors, %d write errors",
 		elapsed.Truncate(time.Second), files, stats.dirs.Load(), rate, stats.preskipped.Load(), stats.dirsEmptyCheck.Load(), stats.statErrors.Load(), stats.matchErrors.Load())
+	if len(symlinkRules) > 0 {
+		l.Info("symlinks: %d visited, %d matched, %d processing errors",
+			stats.symlinks.Load(), stats.matchedSymlinks.Load(), stats.symlinkErrors.Load())
+	}
 	fmt.Fprintln(os.Stderr, "tag\trows\ttotal_bytes")
 	for _, tag := range stats.tags {
 		rows := stats.rowsByTag[tag].Load()

--- a/go/terncli/tagfiles_rules.go
+++ b/go/terncli/tagfiles_rules.go
@@ -19,11 +19,12 @@ import (
 // Tag is an arbitrary string. When a rule fires, its tag selects the
 // output bucket; tag values have no built-in meaning here.
 //
-// AppliesTo is "file" (default) or "directory".
+// AppliesTo is "file" (default), "directory", or "symlink".
 type Rule struct {
 	Name                           string
 	Tag                            string
 	AppliesTo                      string
+	SymlinkTarget                  string
 	IncludePatterns                []*regexp.Regexp
 	ExcludePatterns                []*regexp.Regexp
 	SuffixPatterns                 []*regexp.Regexp
@@ -68,6 +69,7 @@ type ruleJSON struct {
 	Name                           string    `json:"name"`
 	Tag                            string    `json:"tag"`
 	AppliesTo                      string    `json:"applies_to"`
+	SymlinkTarget                  string    `json:"symlink_target"`
 	IncludePathMatch               []string  `json:"include_path_match"`
 	ExcludePathMatch               []string  `json:"exclude_path_match"`
 	FileSuffixMatch                []string  `json:"file_suffix_match"`
@@ -91,8 +93,14 @@ func LoadRules(data []byte) ([]*Rule, error) {
 		if appliesTo == "" {
 			appliesTo = "file"
 		}
-		if appliesTo != "file" && appliesTo != "directory" {
+		if appliesTo != "file" && appliesTo != "directory" && appliesTo != "symlink" {
 			return nil, fmt.Errorf("rule %q has invalid applies_to %q", r.Name, appliesTo)
+		}
+		if r.SymlinkTarget != "" && r.SymlinkTarget != "dangling" && r.SymlinkTarget != "not-dangling" {
+			return nil, fmt.Errorf("rule %q has invalid symlink_target %q", r.Name, r.SymlinkTarget)
+		}
+		if r.SymlinkTarget != "" && appliesTo != "symlink" {
+			return nil, fmt.Errorf("rule %q has symlink_target but applies_to is %q", r.Name, appliesTo)
 		}
 		inc, err := compileAll(r.IncludePathMatch)
 		if err != nil {
@@ -110,6 +118,7 @@ func LoadRules(data []byte) ([]*Rule, error) {
 			Name:                           r.Name,
 			Tag:                            r.Tag,
 			AppliesTo:                      appliesTo,
+			SymlinkTarget:                  r.SymlinkTarget,
 			IncludePatterns:                inc,
 			ExcludePatterns:                exc,
 			SuffixPatterns:                 suf,
@@ -163,6 +172,11 @@ func (r *Rule) Matches(path string, size uint64, atime, mtime, now msgs.TernTime
 			return false
 		}
 	}
+	return r.MatchesPath(path)
+}
+
+// MatchesPath reports whether the rule's path predicates hold.
+func (r *Rule) MatchesPath(path string) bool {
 	if !matchAny(r.IncludePatterns, path) {
 		return false
 	}
@@ -184,6 +198,15 @@ func FirstMatch(rules []*Rule, path string, size uint64, atime, mtime, now msgs.
 		}
 	}
 	return nil
+}
+
+func anyPathMatches(rules []*Rule, path string) bool {
+	for _, r := range rules {
+		if r.MatchesPath(path) {
+			return true
+		}
+	}
+	return false
 }
 
 // MaybeMatchesByCreationTime is a conservative prefilter: returns false

--- a/go/terncli/tagfiles_symlinks.go
+++ b/go/terncli/tagfiles_symlinks.go
@@ -1,0 +1,188 @@
+// Copyright 2025 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"xtx/ternfs/client"
+	"xtx/ternfs/core/bufpool"
+	"xtx/ternfs/core/log"
+	"xtx/ternfs/msgs"
+)
+
+const (
+	maxSymlinkResolutionHops = 40
+)
+
+type symlinkJob struct {
+	id       msgs.InodeId
+	fullPath string
+}
+
+type symlinkFilesystem interface {
+	readlink(msgs.InodeId) (string, error)
+	lookup(msgs.InodeId, string) (msgs.InodeId, error)
+}
+
+type ternSymlinkFilesystem struct {
+	client  *client.Client
+	log     *log.Logger
+	bufPool *bufpool.BufPool
+}
+
+func (fs *ternSymlinkFilesystem) readlink(id msgs.InodeId) (string, error) {
+	r, err := fs.client.ReadFile(fs.log, fs.bufPool, id)
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	target, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(target), nil
+}
+
+func (fs *ternSymlinkFilesystem) lookup(dir msgs.InodeId, name string) (msgs.InodeId, error) {
+	resp := msgs.LookupResp{}
+	if err := fs.client.ShardRequest(fs.log, dir.Shard(), &msgs.LookupReq{
+		DirId: dir,
+		Name:  name,
+	}, &resp); err != nil {
+		return msgs.NULL_INODE_ID, err
+	}
+	return resp.TargetId, nil
+}
+
+func symlinkIsDangling(fs symlinkFilesystem, linkPath string, linkId msgs.InodeId) (bool, error) {
+	target, err := fs.readlink(linkId)
+	if err != nil {
+		return false, fmt.Errorf("readlink: %w", err)
+	}
+	if target == "" {
+		return true, nil
+	}
+	if !path.IsAbs(target) {
+		target = path.Dir(linkPath) + "/" + target
+	}
+	return pathIsMissing(fs, target)
+}
+
+func FirstSymlinkMatch(
+	rules []*Rule,
+	path string,
+	size uint64,
+	atime, mtime, now msgs.TernTime,
+	targetIsDangling func() (bool, error),
+) (*Rule, error) {
+	var (
+		resolved bool
+		dangling bool
+	)
+	for _, rule := range rules {
+		if !rule.Matches(path, size, atime, mtime, now) {
+			continue
+		}
+		if rule.SymlinkTarget == "" {
+			return rule, nil
+		}
+		if !resolved {
+			var err error
+			dangling, err = targetIsDangling()
+			if err != nil {
+				return nil, err
+			}
+			resolved = true
+		}
+		if (rule.SymlinkTarget == "dangling") == dangling {
+			return rule, nil
+		}
+	}
+	return nil, nil
+}
+
+func pathIsMissing(fs symlinkFilesystem, target string) (bool, error) {
+	originalTarget := target
+	pending := strings.Split(target, "/")
+	dirStack := []msgs.InodeId{msgs.ROOT_DIR_INODE_ID}
+	hops := 0
+
+	for len(pending) > 0 {
+		segment := pending[0]
+		pending = pending[1:]
+		switch segment {
+		case "", ".":
+			continue
+		case "..":
+			if len(dirStack) > 1 {
+				dirStack = dirStack[:len(dirStack)-1]
+			}
+			continue
+		}
+
+		currentDir := dirStack[len(dirStack)-1]
+		id, err := fs.lookup(currentDir, segment)
+		if err != nil {
+			if isMissingPathError(err) {
+				return true, nil
+			}
+			return false, err
+		}
+
+		if id.Type() == msgs.SYMLINK {
+			hops++
+			if hops > maxSymlinkResolutionHops {
+				return false, fmt.Errorf("more than %d symlink hops resolving %q", maxSymlinkResolutionHops, originalTarget)
+			}
+			linkTarget, err := fs.readlink(id)
+			if err != nil {
+				if isMissingPathError(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			if linkTarget == "" {
+				return true, nil
+			}
+			if path.IsAbs(linkTarget) {
+				dirStack = dirStack[:1]
+			}
+			pending = append(strings.Split(linkTarget, "/"), pending...)
+			continue
+		}
+
+		if len(pending) == 0 {
+			return false, nil
+		}
+		if id.Type() != msgs.DIRECTORY {
+			return true, nil
+		}
+		dirStack = append(dirStack, id)
+	}
+	return false, nil
+}
+
+func isMissingPathError(err error) bool {
+	return errors.Is(err, msgs.FILE_NOT_FOUND) ||
+		errors.Is(err, msgs.DIRECTORY_NOT_FOUND) ||
+		errors.Is(err, msgs.NAME_NOT_FOUND) ||
+		errors.Is(err, msgs.EDGE_NOT_FOUND)
+}
+
+func symlinkRow(job symlinkJob, resp msgs.StatFileResp, rule *Rule) string {
+	return fmt.Sprintf(
+		"%s\t%d\t%d\t%d\t%s\t%s",
+		job.id.String(),
+		resp.Size,
+		uint64(resp.Atime),
+		uint64(resp.Mtime),
+		rule.Name,
+		job.fullPath,
+	)
+}

--- a/go/terncli/tagfiles_symlinks_test.go
+++ b/go/terncli/tagfiles_symlinks_test.go
@@ -1,0 +1,310 @@
+// Copyright 2025 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+	"xtx/ternfs/msgs"
+)
+
+type fakeSymlinkFilesystem struct {
+	targets map[msgs.InodeId]string
+	entries map[string]msgs.InodeId
+}
+
+func (fs *fakeSymlinkFilesystem) readlink(id msgs.InodeId) (string, error) {
+	target, ok := fs.targets[id]
+	if !ok {
+		return "", msgs.FILE_NOT_FOUND
+	}
+	return target, nil
+}
+
+func (fs *fakeSymlinkFilesystem) lookup(dir msgs.InodeId, name string) (msgs.InodeId, error) {
+	id, ok := fs.entries[fmt.Sprintf("%s/%s", dir.String(), name)]
+	if !ok {
+		return msgs.NULL_INODE_ID, msgs.NAME_NOT_FOUND
+	}
+	return id, nil
+}
+
+type fakeSymlinkTree struct {
+	*fakeSymlinkFilesystem
+	t      *testing.T
+	paths  map[string]msgs.InodeId
+	nextID uint64
+}
+
+func newFakeSymlinkTree(t *testing.T) *fakeSymlinkTree {
+	t.Helper()
+	return &fakeSymlinkTree{
+		fakeSymlinkFilesystem: &fakeSymlinkFilesystem{
+			targets: make(map[msgs.InodeId]string),
+			entries: make(map[string]msgs.InodeId),
+		},
+		t:      t,
+		paths:  map[string]msgs.InodeId{"/": msgs.ROOT_DIR_INODE_ID},
+		nextID: 1,
+	}
+}
+
+func (tree *fakeSymlinkTree) add(pathname string, inodeType msgs.InodeType, target string) msgs.InodeId {
+	tree.t.Helper()
+	if !path.IsAbs(pathname) {
+		tree.t.Fatalf("fake path %q is not absolute", pathname)
+	}
+	pathname = path.Clean(pathname)
+	if _, exists := tree.paths[pathname]; exists {
+		tree.t.Fatalf("fake path %q already exists", pathname)
+	}
+	parentPath := path.Dir(pathname)
+	parent, exists := tree.paths[parentPath]
+	if !exists {
+		tree.t.Fatalf("add parent %q before child %q", parentPath, pathname)
+	}
+	if parent.Type() != msgs.DIRECTORY {
+		tree.t.Fatalf("parent %q of %q is not a directory", parentPath, pathname)
+	}
+
+	id := msgs.MakeInodeId(inodeType, 1, tree.nextID)
+	tree.nextID++
+	tree.paths[pathname] = id
+	tree.entries[fmt.Sprintf("%s/%s", parent.String(), path.Base(pathname))] = id
+	if inodeType == msgs.SYMLINK {
+		tree.targets[id] = target
+	}
+	return id
+}
+
+func (tree *fakeSymlinkTree) addDirectory(pathname string) {
+	tree.t.Helper()
+	tree.add(pathname, msgs.DIRECTORY, "")
+}
+
+func (tree *fakeSymlinkTree) addFile(pathname string) {
+	tree.t.Helper()
+	tree.add(pathname, msgs.FILE, "")
+}
+
+func (tree *fakeSymlinkTree) addSymlink(pathname, target string) msgs.InodeId {
+	tree.t.Helper()
+	return tree.add(pathname, msgs.SYMLINK, target)
+}
+
+func TestSymlinkIsDanglingAbsoluteFileTarget(t *testing.T) {
+	// /data/link -> /data/file
+	tree := newFakeSymlinkTree(t)
+	tree.addDirectory("/data")
+	tree.addFile("/data/file")
+	link := tree.addSymlink("/data/link", "/data/file")
+
+	dangling, err := symlinkIsDangling(tree, "/data/link", link)
+	if err != nil {
+		t.Fatalf("symlinkIsDangling: %v", err)
+	}
+	if dangling {
+		t.Fatal("absolute file target was classified as dangling")
+	}
+}
+
+func TestSymlinkIsDanglingRelativeDirectoryTarget(t *testing.T) {
+	// /data/link -> dir
+	tree := newFakeSymlinkTree(t)
+	tree.addDirectory("/data")
+	tree.addDirectory("/data/dir")
+	link := tree.addSymlink("/data/link", "dir")
+
+	dangling, err := symlinkIsDangling(tree, "/data/link", link)
+	if err != nil {
+		t.Fatalf("symlinkIsDangling: %v", err)
+	}
+	if dangling {
+		t.Fatal("relative directory target was classified as dangling")
+	}
+}
+
+func TestSymlinkIsDanglingMissingRelativeTarget(t *testing.T) {
+	// /data/link -> missing
+	tree := newFakeSymlinkTree(t)
+	tree.addDirectory("/data")
+	link := tree.addSymlink("/data/link", "missing")
+
+	dangling, err := symlinkIsDangling(tree, "/data/link", link)
+	if err != nil {
+		t.Fatalf("symlinkIsDangling: %v", err)
+	}
+	if !dangling {
+		t.Fatal("missing relative target was not classified as dangling")
+	}
+}
+
+func TestSymlinkIsDanglingSymlinkChain(t *testing.T) {
+	// /data/link -> file-link -> /data/file
+	tree := newFakeSymlinkTree(t)
+	tree.addDirectory("/data")
+	tree.addFile("/data/file")
+	tree.addSymlink("/data/file-link", "/data/file")
+	link := tree.addSymlink("/data/link", "file-link")
+
+	dangling, err := symlinkIsDangling(tree, "/data/link", link)
+	if err != nil {
+		t.Fatalf("symlinkIsDangling: %v", err)
+	}
+	if dangling {
+		t.Fatal("symlink chain to a file was classified as dangling")
+	}
+}
+
+func TestSymlinkIsDanglingDotDotAfterSymlink(t *testing.T) {
+	// /data/link -> archive-dir/../file
+	// /data/archive-dir -> /archive/dir
+	// The target therefore resolves to /archive/file, not /data/file.
+	tree := newFakeSymlinkTree(t)
+	tree.addDirectory("/data")
+	tree.addDirectory("/archive")
+	tree.addDirectory("/archive/dir")
+	tree.addFile("/archive/file")
+	tree.addSymlink("/data/archive-dir", "/archive/dir")
+	link := tree.addSymlink("/data/link", "archive-dir/../file")
+
+	dangling, err := symlinkIsDangling(tree, "/data/link", link)
+	if err != nil {
+		t.Fatalf("symlinkIsDangling: %v", err)
+	}
+	if dangling {
+		t.Fatal("target with dot-dot after a symlink was classified as dangling")
+	}
+}
+
+func TestSymlinkIsDanglingTrailingSlashOnFile(t *testing.T) {
+	// /data/link -> file/
+	tree := newFakeSymlinkTree(t)
+	tree.addDirectory("/data")
+	tree.addFile("/data/file")
+	link := tree.addSymlink("/data/link", "file/")
+
+	dangling, err := symlinkIsDangling(tree, "/data/link", link)
+	if err != nil {
+		t.Fatalf("symlinkIsDangling: %v", err)
+	}
+	if !dangling {
+		t.Fatal("regular-file target with a trailing slash was not classified as dangling")
+	}
+}
+
+func TestSymlinkResolutionDoesNotTreatLookupErrorsAsDangling(t *testing.T) {
+	link := msgs.MakeInodeId(msgs.SYMLINK, 1, 1)
+	fs := &fakeSymlinkFilesystem{
+		targets: map[msgs.InodeId]string{link: "/target"},
+		entries: map[string]msgs.InodeId{},
+	}
+
+	errorFS := symlinkFilesystemFuncs{
+		readlinkFunc: fs.readlink,
+		lookupFunc: func(msgs.InodeId, string) (msgs.InodeId, error) {
+			return msgs.NULL_INODE_ID, msgs.TIMEOUT
+		},
+	}
+	dangling, err := symlinkIsDangling(errorFS, "/link", link)
+	if err == nil {
+		t.Fatal("expected lookup error")
+	}
+	if dangling {
+		t.Fatal("lookup error was classified as dangling")
+	}
+}
+
+func TestFirstSymlinkMatchTargetPredicate(t *testing.T) {
+	now := msgs.MakeTernTime(time.Unix(1_700_000_000, 0))
+	rules := []*Rule{
+		{
+			Name:            "dangling",
+			SymlinkTarget:   "dangling",
+			IncludePatterns: []*regexp.Regexp{regexp.MustCompile(".*")},
+			SuffixPatterns:  []*regexp.Regexp{regexp.MustCompile(".*")},
+		},
+		{
+			Name:            "not-dangling",
+			SymlinkTarget:   "not-dangling",
+			IncludePatterns: []*regexp.Regexp{regexp.MustCompile(".*")},
+			SuffixPatterns:  []*regexp.Regexp{regexp.MustCompile(".*")},
+		},
+	}
+	for _, tc := range []struct {
+		name       string
+		isDangling bool
+		want       string
+	}{
+		{"dangling", true, "dangling"},
+		{"not dangling", false, "not-dangling"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := FirstSymlinkMatch(rules, "/link", 0, now, now, now, func() (bool, error) {
+				return tc.isDangling, nil
+			})
+			if err != nil {
+				t.Fatalf("FirstSymlinkMatch: %v", err)
+			}
+			if got == nil || got.Name != tc.want {
+				t.Fatalf("got rule %+v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstSymlinkMatchWithoutTargetPredicateDoesNotResolve(t *testing.T) {
+	now := msgs.MakeTernTime(time.Unix(1_700_000_000, 0))
+	rule := &Rule{
+		Name:            "any",
+		IncludePatterns: []*regexp.Regexp{regexp.MustCompile(".*")},
+		SuffixPatterns:  []*regexp.Regexp{regexp.MustCompile(".*")},
+	}
+	got, err := FirstSymlinkMatch([]*Rule{rule}, "/link", 0, now, now, now, func() (bool, error) {
+		t.Fatal("target resolver called")
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("FirstSymlinkMatch: %v", err)
+	}
+	if got != rule {
+		t.Fatalf("got rule %+v, want %+v", got, rule)
+	}
+}
+
+type symlinkFilesystemFuncs struct {
+	readlinkFunc func(msgs.InodeId) (string, error)
+	lookupFunc   func(msgs.InodeId, string) (msgs.InodeId, error)
+}
+
+func (fs symlinkFilesystemFuncs) readlink(id msgs.InodeId) (string, error) {
+	return fs.readlinkFunc(id)
+}
+
+func (fs symlinkFilesystemFuncs) lookup(dir msgs.InodeId, name string) (msgs.InodeId, error) {
+	return fs.lookupFunc(dir, name)
+}
+
+func TestSymlinkRowContract(t *testing.T) {
+	job := symlinkJob{
+		id:       msgs.MakeInodeId(msgs.SYMLINK, 7, 42),
+		fullPath: "/data/dangling",
+	}
+	resp := msgs.StatFileResp{Size: 12, Atime: 34, Mtime: 56}
+	rule := &Rule{Name: "delete_dangling"}
+	row := symlinkRow(job, resp, rule)
+	fields := strings.Split(row, "\t")
+	if len(fields) != 6 {
+		t.Fatalf("row has %d fields, want 6: %q", len(fields), row)
+	}
+	if fields[0] != job.id.String() || fields[1] != "12" || fields[2] != "34" ||
+		fields[3] != "56" || fields[4] != rule.Name || fields[5] != job.fullPath {
+		t.Fatalf("unexpected row fields: %q", fields)
+	}
+}

--- a/go/terncli/tagfiles_test.go
+++ b/go/terncli/tagfiles_test.go
@@ -60,6 +60,29 @@ func TestLoadRules_AppliesToInvalid(t *testing.T) {
 	}
 }
 
+func TestLoadRules_AppliesToSymlink(t *testing.T) {
+	const j = `[{"name":"x","tag":"DELETE","applies_to":"symlink","symlink_target":"dangling","include_path_match":[".*"],"exclude_path_match":[],"file_suffix_match":[".*"],"atime_days":0,"mtime_days":0,"size_bytes":0,"extended_retention_bitfield_match":null}]`
+	rules := mustLoad(t, j)
+	if rules[0].AppliesTo != "symlink" {
+		t.Fatalf("applies_to = %q, want %q", rules[0].AppliesTo, "symlink")
+	}
+	if rules[0].SymlinkTarget != "dangling" {
+		t.Fatalf("symlink_target = %q, want %q", rules[0].SymlinkTarget, "dangling")
+	}
+}
+
+func TestLoadRules_RejectsInvalidSymlinkTarget(t *testing.T) {
+	const invalid = `[{"name":"x","tag":"DELETE","applies_to":"symlink","symlink_target":"missing","include_path_match":[".*"],"exclude_path_match":[],"file_suffix_match":[".*"],"atime_days":0,"mtime_days":0,"size_bytes":0,"extended_retention_bitfield_match":null}]`
+	if _, err := LoadRules([]byte(invalid)); err == nil {
+		t.Fatal("expected invalid symlink_target to be rejected")
+	}
+
+	const wrongType = `[{"name":"x","tag":"DELETE","applies_to":"file","symlink_target":"dangling","include_path_match":[".*"],"exclude_path_match":[],"file_suffix_match":[".*"],"atime_days":0,"mtime_days":0,"size_bytes":0,"extended_retention_bitfield_match":null}]`
+	if _, err := LoadRules([]byte(wrongType)); err == nil {
+		t.Fatal("expected symlink_target on file rule to be rejected")
+	}
+}
+
 func TestRulePredicate_HappyPath(t *testing.T) {
 	rules := mustLoad(t, oneRuleJSON)
 	now := msgs.MakeTernTime(time.Unix(1_700_000_000, 0))

--- a/go/terncli/tagfiles_test.go
+++ b/go/terncli/tagfiles_test.go
@@ -197,6 +197,22 @@ func TestFirstMatch_FirstWins(t *testing.T) {
 	}
 }
 
+func TestFileRulesApplyOnlyToRegularFiles(t *testing.T) {
+	for _, tc := range []struct {
+		inodeType msgs.InodeType
+		want      bool
+	}{
+		{msgs.FILE, true},
+		{msgs.DIRECTORY, false},
+		{msgs.SYMLINK, false},
+	} {
+		id := msgs.MakeInodeId(tc.inodeType, 0, 1)
+		if got := fileRulesApplyTo(id); got != tc.want {
+			t.Errorf("fileRulesApplyTo(%s) = %v, want %v", tc.inodeType, got, tc.want)
+		}
+	}
+}
+
 // listFinal returns sorted dir entries excluding *.tmp.
 func listFinal(t *testing.T, dir string) []string {
 	t.Helper()


### PR DESCRIPTION
## Summary

Separate symlink handling from file handling. Symlinks no longer match file rules, and symlink rules can be predicated on whether the target is dangling or not-dangling.

## Changes

- Add applies_to: "symlink" rules to terncli tag-files.
- Add optional symlink_target predicates for dangling and not-dangling.
- Resolve absolute, relative and chained targets using the existing walk workers.
- Keep symlinks excluded from normal file rules.
- Preserve the existing six-column output format.

