### PR TITLE
nfsd/testing: improve integration test setup and documentation

### DIFF
--- a/go/nfsd/.gitignore
+++ b/go/nfsd/.gitignore
@@ -1,0 +1,5 @@
+# Copyright 2026 XTX Markets Technologies Limited
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+/.deps/

--- a/go/nfsd/Makefile
+++ b/go/nfsd/Makefile
@@ -1,0 +1,63 @@
+# Copyright 2026 XTX Markets Technologies Limited
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+LIBNFS_REPOSITORY := https://github.com/sahlberg/libnfs.git
+LIBNFS_VERSION := 5.0.2
+LIBNFS_REVISION := libnfs-$(LIBNFS_VERSION)
+
+DEPS_DIR := $(CURDIR)/.deps
+LIBNFS_SOURCE := $(DEPS_DIR)/libnfs-$(LIBNFS_VERSION)
+LIBNFS_BUILD := $(DEPS_DIR)/libnfs-build-$(LIBNFS_VERSION)
+LIBNFS_INSTALL := $(DEPS_DIR)/libnfs-install
+LIBNFS_FETCHED := $(LIBNFS_SOURCE)/.ternfs-fetched
+LIBNFS_BUILT := $(LIBNFS_INSTALL)/.ternfs-built-$(LIBNFS_VERSION)
+
+GO_TEST_FLAGS ?=
+
+.DEFAULT_GOAL := help
+
+.PHONY: help test test-cluster fetch-libnfs build-libnfs test-libnfs clean-libnfs
+
+help:
+	@printf '%s\n' \
+		'Available targets:' \
+		'  test             Run the default Go tests' \
+		'  test-cluster     Run the TernFS-backed tests' \
+		'  fetch-libnfs     Fetch the pinned libnfs source' \
+		'  build-libnfs     Build and install libnfs under .deps' \
+		'  test-libnfs      Build libnfs and run its client tests verbosely' \
+		'  clean-libnfs     Remove downloaded and built libnfs files' \
+		'' \
+		'Set GO_TEST_FLAGS to pass additional arguments to Go test targets.'
+
+test:
+	go test $(GO_TEST_FLAGS) .
+
+test-cluster:
+	go test -tags ternnfs $(GO_TEST_FLAGS) .
+
+fetch-libnfs: $(LIBNFS_FETCHED)
+
+$(LIBNFS_FETCHED):
+	mkdir -p "$(DEPS_DIR)"
+	git clone --branch "$(LIBNFS_REVISION)" --depth 1 \
+		"$(LIBNFS_REPOSITORY)" "$(LIBNFS_SOURCE)"
+	touch "$@"
+
+build-libnfs: $(LIBNFS_BUILT)
+
+$(LIBNFS_BUILT): $(LIBNFS_FETCHED)
+	cmake -S "$(LIBNFS_SOURCE)" -B "$(LIBNFS_BUILD)" \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX="$(LIBNFS_INSTALL)" \
+		-DBUILD_SHARED_LIBS=ON
+	cmake --build "$(LIBNFS_BUILD)" --parallel
+	cmake --install "$(LIBNFS_BUILD)"
+	touch "$@"
+
+test-libnfs: $(LIBNFS_BUILT)
+	go test -count=1 -v -tags libnfs -run '^TestLibnfs_' $(GO_TEST_FLAGS) .
+
+clean-libnfs:
+	rm -rf "$(DEPS_DIR)"

--- a/go/nfsd/README.md
+++ b/go/nfsd/README.md
@@ -1,0 +1,113 @@
+<!--
+Copyright 2026 XTX Markets Technologies Limited
+
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+# Testing nfsd
+
+`nfsd` is an NFSv4.0 adapter for TernFS. TernFS is not a general-purpose
+POSIX filesystem: files are immutable after creation, ownership and mode are
+synthetic, and file locking is not supported. Tests must therefore distinguish
+between:
+
+- behavior which the server supports;
+- operations which the server must reject with the correct NFS status; and
+- NFS features which are outside the intended TernFS contract.
+
+There are currently four test paths.
+
+## Protocol tests
+
+Run the default Go tests from this directory:
+
+```sh
+make test
+```
+
+[`nfsd_test.go`](nfsd_test.go) starts the server on a local TCP socket with a
+local filesystem backend. The tests construct NFS RPC messages directly. They
+cover RPC framing, compound processing, filehandles, attributes, directory
+traversal, reads, staged writes, client and open state, replay behavior, and
+expected errors for unsupported operations.
+
+**These tests run as part of the CI functional-test step through `go test ./...`.**
+
+## TernFS-backed protocol tests
+
+[`cluster_test.go`](cluster_test.go) contains tests behind the `ternnfs` build
+tag. The intended command is:
+
+```sh
+make test-cluster
+```
+
+The test `TestMain` builds and starts a temporary TernFS cluster, including the
+registry, block services, CDC and metadata shards. Each test starts an NFS
+server backed by that cluster and sends NFS RPC messages directly.
+
+This suite exercises the TernFS backend but still uses the test's own RPC
+client.
+
+**This test is currently not run in any CI workflow.**
+
+## libnfs tests
+
+[`libnfs_test.go`](libnfs_test.go) uses
+[libnfs](https://github.com/sahlberg/libnfs) as an independent NFS client. The
+tests are behind the `libnfs` build tag.
+
+Fetch the pinned libnfs source:
+
+```sh
+make fetch-libnfs
+```
+
+The pinned release is libnfs 5.0.2.
+
+Run the tests:
+
+```sh
+make test-libnfs
+```
+
+`test-libnfs` builds and installs libnfs under `.deps/libnfs-install` when
+needed, then runs the 11 `TestLibnfs_*` cases verbosely against a server with
+the local filesystem backend. It disables the Go test cache so that each
+invocation exercises the client and server. The downloaded source and
+installation are ignored by git. Use `make clean-libnfs` to remove them.
+Fetching requires git; building requires CMake and a C compiler.
+
+This suite is not run by CI.
+
+All Go test targets accept additional flags through `GO_TEST_FLAGS`. For
+example:
+
+```sh
+make test-cluster GO_TEST_FLAGS='-v -run TestTernWriteAndRead'
+```
+
+## Linux kernel client integration test
+
+CI runs a separate NFS test in a QEMU Ubuntu VM:
+
+```sh
+./ci.py --short --prepare-image <noble-cloud-image> --nfs --leader-only
+```
+
+[`ci_nfs.sh`](../../ci_nfs.sh) deploys a built TernFS cluster and `nfsd` into
+the VM. [`terntests`](../terntests) then mounts the server using the Linux
+NFSv4.0 client and runs `terntests -nfs -filter nfs`.
+
+That filter selects exactly two tests:
+
+- [`nfs mounted fs`](../terntests/terntests.go) runs the existing `fsTest`
+  workload through its `posixHarness`, with the NFS mount as its root. In short
+  mode this uses 10 directories and 500 files.
+- [`nfs mutations`](../terntests/nfsmutate.go) is the NFS-specific mutation
+  suite. It checks create/write/readback, out-of-order writes, rename, delete,
+  timestamp updates, and rejection of in-place modification.
+
+This is the only current test path using a kernel NFS client. CI runs it with a
+single LogsDB leader and disables migration, defragmentation and corruption
+injection.

--- a/go/nfsd/README.md
+++ b/go/nfsd/README.md
@@ -78,7 +78,7 @@ invocation exercises the client and server. The downloaded source and
 installation are ignored by git. Use `make clean-libnfs` to remove them.
 Fetching requires git; building requires CMake and a C compiler.
 
-This suite is not run by CI.
+**This test is currently not run in any CI workflow.**
 
 All Go test targets accept additional flags through `GO_TEST_FLAGS`. For
 example:
@@ -108,6 +108,4 @@ That filter selects exactly two tests:
   suite. It checks create/write/readback, out-of-order writes, rename, delete,
   timestamp updates, and rejection of in-place modification.
 
-This is the only current test path using a kernel NFS client. CI runs it with a
-single LogsDB leader and disables migration, defragmentation and corruption
-injection.
+This is the only current test path using a kernel NFS client.

--- a/go/nfsd/cluster_test.go
+++ b/go/nfsd/cluster_test.go
@@ -118,7 +118,9 @@ func TestMain(m *testing.M) {
 		})
 	}
 	fmt.Println("waiting for block services...")
-	client.WaitForBlockServices(ternLogger, registryAddr, failureDomains*servicesPerDomain, true, 30*time.Second)
+	if _, err := client.WaitForBlockServices(ternLogger, registryAddr, failureDomains*servicesPerDomain, 30*time.Second); err != nil {
+		panic(fmt.Errorf("failed to wait for block services: %w", err))
+	}
 
 	// Start CDC (single replica).
 	procs.StartCDC(ternLogger, *repoDir, &managedprocess.CDCOpts{
@@ -132,16 +134,18 @@ func TestMain(m *testing.M) {
 	})
 
 	// Start 256 shards (single replica each).
+	noWritableDelay := time.Duration(0)
 	for i := 0; i < 256; i++ {
 		shrid := msgs.MakeShardReplicaId(msgs.ShardId(i), 0)
 		procs.StartShard(ternLogger, *repoDir, &managedprocess.ShardOpts{
-			Exe:             cppExes.ShardExe,
-			Dir:             path.Join(dataDir, fmt.Sprintf("shard_%03d", i)),
-			LogLevel:        log.INFO,
-			Shrid:           shrid,
-			RegistryAddress: registryAddr,
-			Addr1:           "127.0.0.1:0",
-			LogsDBFlags:     []string{"-logsdb-leader", "-logsdb-no-replication", "-logsdb-initial-start"},
+			Exe:                       cppExes.ShardExe,
+			Dir:                       path.Join(dataDir, fmt.Sprintf("shard_%03d", i)),
+			LogLevel:                  log.INFO,
+			Shrid:                     shrid,
+			RegistryAddress:           registryAddr,
+			Addr1:                     "127.0.0.1:0",
+			BlockServiceWritableDelay: &noWritableDelay,
+			LogsDBFlags:               []string{"-logsdb-leader", "-logsdb-no-replication", "-logsdb-initial-start"},
 		})
 	}
 

--- a/go/nfsd/libnfs_cgo.go
+++ b/go/nfsd/libnfs_cgo.go
@@ -7,11 +7,24 @@
 package main
 
 /*
-#cgo CFLAGS: -I/tmp/libnfs-install/include
-#cgo LDFLAGS: -L/tmp/libnfs-install/lib -lnfs -Wl,-rpath,/tmp/libnfs-install/lib
+#cgo CFLAGS: -I${SRCDIR}/.deps/libnfs-install/include
+#cgo LDFLAGS: -L${SRCDIR}/.deps/libnfs-install/lib -lnfs -Wl,-rpath,${SRCDIR}/.deps/libnfs-install/lib
 #include <stdlib.h>
 #include <fcntl.h>
 #include <nfsc/libnfs.h>
+
+static int tern_nfs_mount_url(struct nfs_context *nfs, const char *url)
+{
+	struct nfs_url *parsed = nfs_parse_url_dir(nfs, url);
+	int ret;
+
+	if (parsed == NULL) {
+		return -1;
+	}
+	ret = nfs_mount(nfs, parsed->server, parsed->path);
+	nfs_destroy_url(parsed);
+	return ret;
+}
 */
 import "C"
 
@@ -29,21 +42,23 @@ func libnfsConnect(host string, port int) (*libnfsClient, error) {
 	if nfs == nil {
 		return nil, fmt.Errorf("nfs_init_context failed")
 	}
-	C.nfs_set_version(nfs, 4)
-	C.nfs_set_nfsport(nfs, C.int(port))
+	if ret := C.nfs_set_version(nfs, 4); ret != 0 {
+		msg := C.GoString(C.nfs_get_error(nfs))
+		C.nfs_destroy_context(nfs)
+		return nil, fmt.Errorf("nfs_set_version: %s (ret=%d)", msg, ret)
+	}
 	C.nfs_set_timeout(nfs, 5000)
 	C.nfs_set_debug(nfs, 2)
 
-	chost := C.CString(host)
-	defer C.free(unsafe.Pointer(chost))
-	cexport := C.CString("/")
-	defer C.free(unsafe.Pointer(cexport))
+	mountURL := fmt.Sprintf("nfs://%s/?nfsport=%d", host, port)
+	curl := C.CString(mountURL)
+	defer C.free(unsafe.Pointer(curl))
 
-	ret := C.nfs_mount(nfs, chost, cexport)
+	ret := C.tern_nfs_mount_url(nfs, curl)
 	if ret != 0 {
 		msg := C.GoString(C.nfs_get_error(nfs))
 		C.nfs_destroy_context(nfs)
-		return nil, fmt.Errorf("nfs_mount: %s (ret=%d)", msg, ret)
+		return nil, fmt.Errorf("nfs_mount %q: %s (ret=%d)", mountURL, msg, ret)
 	}
 	return &libnfsClient{nfs: nfs}, nil
 }
@@ -91,7 +106,7 @@ func (c *libnfsClient) ReadFile(path string) ([]byte, error) {
 	var result []byte
 	buf := make([]byte, 64*1024)
 	for {
-		n := C.nfs_read(c.nfs, fh, unsafe.Pointer(&buf[0]), C.size_t(len(buf)))
+		n := C.nfs_read(c.nfs, fh, C.uint64_t(len(buf)), unsafe.Pointer(&buf[0]))
 		if n < 0 {
 			msg := C.GoString(C.nfs_get_error(c.nfs))
 			return nil, fmt.Errorf("nfs_read(%q): %s", path, msg)

--- a/go/nfsd/server.go
+++ b/go/nfsd/server.go
@@ -7,8 +7,11 @@ package main
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
+	"io"
 	"log/slog"
 	"net"
+	"syscall"
 	"time"
 )
 
@@ -87,6 +90,8 @@ func (s *Server) handleConn(conn net.Conn) {
 		if err != nil {
 			if ne, ok := err.(net.Error); ok && ne.Timeout() {
 				s.log.Info("client idle timeout", "remote", remote)
+			} else if errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) {
+				s.log.Info("client disconnected", "remote", remote)
 			} else {
 				s.log.Info("client disconnected", "remote", remote, "err", err)
 			}


### PR DESCRIPTION
## Summary

* Add `go/nfsd/Makefile` to run all the existing test suites and install/build libnfs
* Add `go/nfsd/README.md` describing the existing test suites
* Fix the temporary cluster’s block-service readiness setup.
* Treat EOF and peer resets as normal disconnects (reduce test noise)
