### PR TITLE
nfsd/testing: Add py-nfs test harness

### DIFF
--- a/go/nfsd/Makefile
+++ b/go/nfsd/Makefile
@@ -13,11 +13,25 @@ LIBNFS_INSTALL := $(DEPS_DIR)/libnfs-install
 LIBNFS_FETCHED := $(LIBNFS_SOURCE)/.ternfs-fetched
 LIBNFS_BUILT := $(LIBNFS_INSTALL)/.ternfs-built-$(LIBNFS_VERSION)
 
+PYNFS_REPOSITORY := https://github.com/linux-nfs/pynfs.git
+PYNFS_REVISION := pynfs-0.5
+PYNFS_SOURCE := $(DEPS_DIR)/pynfs
+PYNFS_FETCHED := $(PYNFS_SOURCE)/.ternfs-fetched
+PYNFS_BUILT := $(PYNFS_SOURCE)/.ternfs-built
+
 GO_TEST_FLAGS ?=
+SS ?= ss
+PYNFS_PYTHON ?= python3
+PYNFS_TESTS ?= all
+PYNFS_ARGS ?=
+PYNFS_TIMEOUT ?= 1h
+TERNFS_REGISTRY_HOST ?= 127.0.0.1
+TERNFS_REGISTRY_PORT ?= 55556
 
 .DEFAULT_GOAL := help
 
-.PHONY: help test test-cluster fetch-libnfs build-libnfs test-libnfs clean-libnfs
+.PHONY: help check-cluster-port test test-cluster fetch-libnfs build-libnfs \
+	test-libnfs clean-libnfs fetch-pynfs build-pynfs test-pynfs-cluster clean-pynfs
 
 help:
 	@printf '%s\n' \
@@ -28,13 +42,29 @@ help:
 		'  build-libnfs     Build and install libnfs under .deps' \
 		'  test-libnfs      Build libnfs and run its client tests verbosely' \
 		'  clean-libnfs     Remove downloaded and built libnfs files' \
+		'  fetch-pynfs      Fetch the pinned pynfs source under .deps' \
+		'  build-pynfs      Generate the pynfs NFSv4.0 modules' \
+		'  test-pynfs-cluster  Run pynfs against a temporary TernFS cluster' \
+		'  clean-pynfs      Remove downloaded and built pynfs files' \
 		'' \
-		'Set GO_TEST_FLAGS to pass additional arguments to Go test targets.'
+		'Test targets ending in -cluster start a temporary TernFS cluster.' \
+		'Set GO_TEST_FLAGS to pass additional arguments to Go test targets.' \
+		'Set PYNFS_TESTS, PYNFS_ARGS and PYNFS_TIMEOUT to configure pynfs.'
 
 test:
 	go test $(GO_TEST_FLAGS) .
 
-test-cluster:
+check-cluster-port:
+	@command -v "$(SS)" >/dev/null 2>&1 || { \
+		echo "error: $(SS) is required to check for an existing TernFS test cluster" >&2; \
+		exit 1; \
+	}
+	@if [ -n "$$("$(SS)" -H -lun "sport = :$(TERNFS_REGISTRY_PORT)")" ]; then \
+		echo "error: UDP port $(TERNFS_REGISTRY_HOST):$(TERNFS_REGISTRY_PORT) is already in use; stop the existing TernFS test cluster" >&2; \
+		exit 1; \
+	fi
+
+test-cluster: check-cluster-port
 	go test -tags ternnfs $(GO_TEST_FLAGS) .
 
 fetch-libnfs: $(LIBNFS_FETCHED)
@@ -60,4 +90,30 @@ test-libnfs: $(LIBNFS_BUILT)
 	go test -count=1 -v -tags libnfs -run '^TestLibnfs_' $(GO_TEST_FLAGS) .
 
 clean-libnfs:
-	rm -rf "$(DEPS_DIR)"
+	rm -rf "$(LIBNFS_SOURCE)" "$(LIBNFS_BUILD)" "$(LIBNFS_INSTALL)"
+
+fetch-pynfs: $(PYNFS_FETCHED)
+
+$(PYNFS_FETCHED):
+	mkdir -p "$(DEPS_DIR)"
+	git clone --branch "$(PYNFS_REVISION)" --depth 1 \
+		"$(PYNFS_REPOSITORY)" "$(PYNFS_SOURCE)"
+	touch "$@"
+
+build-pynfs: $(PYNFS_BUILT)
+
+$(PYNFS_BUILT): $(PYNFS_FETCHED)
+	cd "$(PYNFS_SOURCE)/nfs4.0" && \
+		"$(PYNFS_PYTHON)" setup.py build_ext --inplace
+	touch "$@"
+
+test-pynfs-cluster: $(PYNFS_BUILT) check-cluster-port
+	PYNFS_SOURCE="$(PYNFS_SOURCE)" \
+	PYNFS_PYTHON="$(PYNFS_PYTHON)" \
+	PYNFS_TESTS="$(PYNFS_TESTS)" \
+	PYNFS_ARGS="$(PYNFS_ARGS)" \
+	go test -count=1 -v -timeout "$(PYNFS_TIMEOUT)" \
+		-tags 'ternnfs pynfs' -run '^TestPynfs$$' $(GO_TEST_FLAGS) .
+
+clean-pynfs:
+	rm -rf "$(PYNFS_SOURCE)"

--- a/go/nfsd/Makefile
+++ b/go/nfsd/Makefile
@@ -25,8 +25,9 @@ PYNFS_BUILT := $(PYNFS_SOURCE)/.ternfs-built
 GO_TEST_FLAGS ?=
 SS ?= ss
 PYNFS_PYTHON ?= python3
-PYNFS_TESTS ?= all
+PYNFS_TESTS ?= all noblock nochar nofifo nosocket nogss noacl nomode000
 PYNFS_ARGS ?=
+PYNFS_SKIP_FILE ?= $(CURDIR)/pynfs_unsupported.txt
 PYNFS_OUTPUT ?= $(CURDIR)/pynfs.out
 PYNFS_TIMEOUT ?= 1h
 TERNFS_REGISTRY_HOST ?= 127.0.0.1
@@ -53,7 +54,7 @@ help:
 		'' \
 		'Test targets ending in -cluster start a temporary TernFS cluster.' \
 		'Set GO_TEST_FLAGS to pass additional arguments to Go test targets.' \
-		'Set PYNFS_TESTS, PYNFS_ARGS, PYNFS_OUTPUT and PYNFS_TIMEOUT to configure pynfs.'
+		'Set PYNFS_TESTS, PYNFS_ARGS, PYNFS_SKIP_FILE, PYNFS_OUTPUT and PYNFS_TIMEOUT to configure pynfs.'
 
 test:
 	go test $(GO_TEST_FLAGS) .
@@ -116,6 +117,7 @@ test-pynfs-cluster: $(PYNFS_BUILT) check-cluster-port
 	PYNFS_PYTHON="$(PYNFS_PYTHON)" \
 	PYNFS_TESTS="$(PYNFS_TESTS)" \
 	PYNFS_ARGS="$(PYNFS_ARGS)" \
+	PYNFS_SKIP_FILE="$(PYNFS_SKIP_FILE)" \
 	go test -count=1 -v -timeout "$(PYNFS_TIMEOUT)" \
 		-tags 'ternnfs pynfs' -run '^TestPynfs$$' $(GO_TEST_FLAGS) . \
 		2>&1 | tee "$(PYNFS_OUTPUT)"

--- a/go/nfsd/Makefile
+++ b/go/nfsd/Makefile
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+
 LIBNFS_REPOSITORY := https://github.com/sahlberg/libnfs.git
 LIBNFS_VERSION := 5.0.2
 LIBNFS_REVISION := libnfs-$(LIBNFS_VERSION)
@@ -24,6 +27,7 @@ SS ?= ss
 PYNFS_PYTHON ?= python3
 PYNFS_TESTS ?= all
 PYNFS_ARGS ?=
+PYNFS_OUTPUT ?= $(CURDIR)/pynfs.out
 PYNFS_TIMEOUT ?= 1h
 TERNFS_REGISTRY_HOST ?= 127.0.0.1
 TERNFS_REGISTRY_PORT ?= 55556
@@ -49,7 +53,7 @@ help:
 		'' \
 		'Test targets ending in -cluster start a temporary TernFS cluster.' \
 		'Set GO_TEST_FLAGS to pass additional arguments to Go test targets.' \
-		'Set PYNFS_TESTS, PYNFS_ARGS and PYNFS_TIMEOUT to configure pynfs.'
+		'Set PYNFS_TESTS, PYNFS_ARGS, PYNFS_OUTPUT and PYNFS_TIMEOUT to configure pynfs.'
 
 test:
 	go test $(GO_TEST_FLAGS) .
@@ -113,7 +117,8 @@ test-pynfs-cluster: $(PYNFS_BUILT) check-cluster-port
 	PYNFS_TESTS="$(PYNFS_TESTS)" \
 	PYNFS_ARGS="$(PYNFS_ARGS)" \
 	go test -count=1 -v -timeout "$(PYNFS_TIMEOUT)" \
-		-tags 'ternnfs pynfs' -run '^TestPynfs$$' $(GO_TEST_FLAGS) .
+		-tags 'ternnfs pynfs' -run '^TestPynfs$$' $(GO_TEST_FLAGS) . \
+		2>&1 | tee "$(PYNFS_OUTPUT)"
 
 clean-pynfs:
 	rm -rf "$(PYNFS_SOURCE)"

--- a/go/nfsd/README.md
+++ b/go/nfsd/README.md
@@ -123,6 +123,10 @@ temporary TernFS cluster and `nfsd`, runs pynfs with `--maketree --rundeps`,
 and reads pynfs's JSON results so protocol failures fail the Go test. Pynfs
 itself otherwise exits successfully when individual tests fail.
 
+The Make target writes the complete console output to `pynfs.out` while also
+displaying it. Set `PYNFS_OUTPUT` to use another path. The output file is not
+ignored by git, so completed runs remain visible during review.
+
 The standard suite includes behavior outside the TernFS contract, so an
 initial run is expected to expose unsupported operations as well as server
 bugs. Select flags or individual pynfs test codes with `PYNFS_TESTS`, and pass

--- a/go/nfsd/README.md
+++ b/go/nfsd/README.md
@@ -127,17 +127,28 @@ The Make target writes the complete console output to `pynfs.out` while also
 displaying it. Set `PYNFS_OUTPUT` to use another path. The output file is not
 ignored by git, so completed runs remain visible during review.
 
-The standard suite includes behavior outside the TernFS contract, so an
-initial run is expected to expose unsupported operations as well as server
-bugs. Select flags or individual pynfs test codes with `PYNFS_TESTS`, and pass
-additional runner options with `PYNFS_ARGS`. The default Go test timeout is one
-hour because pynfs includes lease-expiry cases which deliberately sleep for
-several minutes. Override it with `PYNFS_TIMEOUT`:
+TernFS intentionally does not implement several POSIX and NFS features covered
+by pynfs. The harness uses two mechanisms to exclude those tests:
+
+* The default `PYNFS_TESTS` value uses pynfs flag selectors to exclude broad
+  capability classes such as FIFO, socket, GSS and ACL tests.
+* The [`pynfs_unsupported.txt`](pynfs_unsupported.txt) manifest lists
+  individual locking and hard-link cases. Using the broad `nolock` and
+  `nolink` selectors would also hide useful related tests.
+
+Select flags or individual pynfs test codes with `PYNFS_TESTS`. The manifest
+exclusions are appended after `PYNFS_TESTS`, so set `PYNFS_SKIP_FILE=` to
+bypass this manifest.
+
+Set additional runner options with `PYNFS_ARGS`. The default Go test timeout is
+one hour because pynfs includes lease-expiry cases which deliberately sleep
+for several minutes. Override it with `PYNFS_TIMEOUT`:
 
 ```sh
 make test-pynfs-cluster PYNFS_TESTS='putrootfh getattr'
 make test-pynfs-cluster PYNFS_TESTS='GETATTR1 GETATTR2' PYNFS_ARGS='--showtraffic'
-make test-pynfs-cluster PYNFS_TESTS='all notimed'
+make test-pynfs-cluster PYNFS_TESTS='all notimed noblock nochar nofifo nosocket nogss noacl nomode000'
+make test-pynfs-cluster PYNFS_TESTS='all notimed' PYNFS_SKIP_FILE=
 make test-pynfs-cluster PYNFS_TIMEOUT=2h
 ```
 

--- a/go/nfsd/README.md
+++ b/go/nfsd/README.md
@@ -15,7 +15,19 @@ between:
 - operations which the server must reject with the correct NFS status; and
 - NFS features which are outside the intended TernFS contract.
 
-There are currently four test paths.
+There are currently five test paths.
+
+Test targets ending in `-cluster` build and start a temporary TernFS cluster.
+Test targets without that suffix do not use a TernFS cluster. For example,
+`test-libnfs` runs against the local filesystem backend. Pynfs only has a
+cluster-backed mode, so its target is `test-pynfs-cluster`; there is no
+`test-pynfs` target.
+
+Cluster-backed targets use `ss` to check the fixed registry UDP port
+`127.0.0.1:55556` before starting. They fail with an explicit error if another
+test cluster is already using that port. This check does not require root.
+Install `ss` (provided by the `iproute2` package on Debian and Ubuntu) before
+running these targets.
 
 ## Protocol tests
 
@@ -79,6 +91,59 @@ installation are ignored by git. Use `make clean-libnfs` to remove them.
 Fetching requires git; building requires CMake and a C compiler.
 
 **This test is currently not run in any CI workflow.**
+
+## pynfs protocol tests
+
+[pynfs](https://github.com/linux-nfs/pynfs) is the Linux NFS project's
+protocol test suite. The Makefile pins release `pynfs-0.5` and uses its
+NFSv4.0 server tests.
+
+Fetch and build pynfs:
+
+```sh
+make fetch-pynfs
+make build-pynfs
+```
+
+The build requires Python 3, setuptools and PLY. On Debian and Ubuntu, install
+the latter two with:
+
+```sh
+sudo apt-get install python3-setuptools python3-ply
+```
+
+Run the standard pynfs suite:
+
+```sh
+make test-pynfs-cluster
+```
+
+[`pynfs_test.go`](pynfs_test.go) reuses the `ternnfs` test harness. It starts a
+temporary TernFS cluster and `nfsd`, runs pynfs with `--maketree --rundeps`,
+and reads pynfs's JSON results so protocol failures fail the Go test. Pynfs
+itself otherwise exits successfully when individual tests fail.
+
+The standard suite includes behavior outside the TernFS contract, so an
+initial run is expected to expose unsupported operations as well as server
+bugs. Select flags or individual pynfs test codes with `PYNFS_TESTS`, and pass
+additional runner options with `PYNFS_ARGS`. The default Go test timeout is one
+hour because pynfs includes lease-expiry cases which deliberately sleep for
+several minutes. Override it with `PYNFS_TIMEOUT`:
+
+```sh
+make test-pynfs-cluster PYNFS_TESTS='putrootfh getattr'
+make test-pynfs-cluster PYNFS_TESTS='GETATTR1 GETATTR2' PYNFS_ARGS='--showtraffic'
+make test-pynfs-cluster PYNFS_TESTS='all notimed'
+make test-pynfs-cluster PYNFS_TIMEOUT=2h
+```
+
+Pynfs tags eight standard cases as `timed`; these exercise lease expiry and
+can each wait for 135 or 180 seconds with nfsd's 90-second lease. The harness
+runs Python unbuffered and reports tests taking at least one second, sorted by
+duration, after pynfs writes its results.
+
+Use `make clean-pynfs` to remove the source and generated files. This suite is
+not currently run in CI.
 
 All Go test targets accept additional flags through `GO_TEST_FLAGS`. For
 example:

--- a/go/nfsd/cluster_test.go
+++ b/go/nfsd/cluster_test.go
@@ -162,9 +162,18 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
+	var closeProcs sync.Once
+	cleanupProcs := func() {
+		closeProcs.Do(procs.Close)
+	}
+	timeoutCleanup := cleanupBeforeTestTimeout(cleanupProcs)
+
 	code := m.Run()
 
-	procs.Close()
+	if timeoutCleanup != nil {
+		timeoutCleanup.Stop()
+	}
+	cleanupProcs()
 	logFile.Close()
 	if code == 0 {
 		os.RemoveAll(dataDir)
@@ -172,6 +181,24 @@ func TestMain(m *testing.M) {
 		fmt.Printf("test data preserved at %s\n", dataDir)
 	}
 	os.Exit(code)
+}
+
+func cleanupBeforeTestTimeout(cleanup func()) *time.Timer {
+	timeoutFlag := flag.Lookup("test.timeout")
+	if timeoutFlag == nil {
+		return nil
+	}
+	timeout, err := time.ParseDuration(timeoutFlag.Value.String())
+	if err != nil || timeout <= 0 {
+		return nil
+	}
+
+	const cleanupGrace = 30 * time.Second
+	grace := min(cleanupGrace, timeout/2)
+	return time.AfterFunc(timeout-grace, func() {
+		fmt.Fprintf(os.Stderr, "test timeout approaching; terminating cluster processes\n")
+		cleanup()
+	})
 }
 
 // startTernTestServer creates an NFS server backed by the shared TernFS cluster.

--- a/go/nfsd/pynfs_test.go
+++ b/go/nfsd/pynfs_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build ternnfs && pynfs
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type pynfsCaseTiming struct {
+	code     string
+	name     string
+	duration time.Duration
+}
+
+func TestPynfs(t *testing.T) {
+	source := os.Getenv("PYNFS_SOURCE")
+	if source == "" {
+		source = filepath.Join(".deps", "pynfs")
+	}
+	source, err := filepath.Abs(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	python := os.Getenv("PYNFS_PYTHON")
+	if python == "" {
+		python = "python3"
+	}
+
+	testServer := filepath.Join(source, "nfs4.0", "testserver.py")
+	if _, err := os.Stat(testServer); err != nil {
+		t.Fatalf("pynfs runner not found: %v; run make fetch-pynfs", err)
+	}
+
+	addr, cleanup := startTernTestServer(t)
+	defer cleanup()
+
+	resultsPath := filepath.Join(t.TempDir(), "pynfs-results.json")
+	args := []string{
+		"-u",
+		testServer,
+		fmt.Sprintf("nfs://%s/", addr),
+		"--maketree",
+		"--rundeps",
+		"--verbose",
+		"--jsonout", resultsPath,
+	}
+	args = append(args, strings.Fields(os.Getenv("PYNFS_ARGS"))...)
+
+	selectors := strings.Fields(os.Getenv("PYNFS_TESTS"))
+	if len(selectors) == 0 {
+		selectors = []string{"all"}
+	}
+	args = append(args, selectors...)
+
+	cmd := exec.Command(python, args...)
+	cmd.Dir = filepath.Join(source, "nfs4.0")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("pynfs runner failed: %v", err)
+	}
+
+	data, err := os.ReadFile(resultsPath)
+	if err != nil {
+		t.Fatalf("read pynfs results: %v", err)
+	}
+	var results struct {
+		Tests    int `json:"tests"`
+		Errors   int `json:"errors"`
+		Failures int `json:"failures"`
+		Skipped  int `json:"skipped"`
+		Testcase []struct {
+			Code string `json:"code"`
+			Name string `json:"name"`
+			Time string `json:"time"`
+		} `json:"testcase"`
+	}
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("decode pynfs results: %v", err)
+	}
+	var slowTests []pynfsCaseTiming
+	for _, testCase := range results.Testcase {
+		seconds, err := strconv.ParseFloat(testCase.Time, 64)
+		if err != nil {
+			t.Fatalf("decode duration for pynfs test %s: %v", testCase.Code, err)
+		}
+		duration := time.Duration(seconds * float64(time.Second))
+		if duration >= time.Second {
+			slowTests = append(slowTests, pynfsCaseTiming{
+				code:     testCase.Code,
+				name:     testCase.Name,
+				duration: duration,
+			})
+		}
+	}
+	sort.Slice(slowTests, func(i, j int) bool {
+		return slowTests[i].duration > slowTests[j].duration
+	})
+	for _, testCase := range slowTests {
+		t.Logf("slow pynfs test: code=%s duration=%s name=%s",
+			testCase.code, testCase.duration.Round(time.Millisecond), testCase.name)
+	}
+	t.Logf("pynfs results: tests=%d failures=%d errors=%d skipped=%d",
+		results.Tests, results.Failures, results.Errors, results.Skipped)
+	if results.Failures != 0 || results.Errors != 0 {
+		t.Fatalf("pynfs reported %d failures and %d errors",
+			results.Failures, results.Errors)
+	}
+}

--- a/go/nfsd/pynfs_test.go
+++ b/go/nfsd/pynfs_test.go
@@ -7,11 +7,13 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +25,44 @@ type pynfsCaseTiming struct {
 	code     string
 	name     string
 	duration time.Duration
+}
+
+var pynfsCodePattern = regexp.MustCompile(`^[A-Z][A-Z0-9]*[a-z]?$`)
+
+func pynfsSkipSelectors(path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var selectors []string
+	seen := make(map[string]int)
+	scanner := bufio.NewScanner(file)
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !pynfsCodePattern.MatchString(line) {
+			return nil, fmt.Errorf("%s:%d: invalid pynfs test code %q",
+				path, lineNumber, line)
+		}
+		if previousLine, ok := seen[line]; ok {
+			return nil, fmt.Errorf("%s:%d: duplicate pynfs test code %q (first on line %d)",
+				path, lineNumber, line, previousLine)
+		}
+		seen[line] = lineNumber
+		selectors = append(selectors, "no"+line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return selectors, nil
 }
 
 func TestPynfs(t *testing.T) {
@@ -64,6 +104,15 @@ func TestPynfs(t *testing.T) {
 	if len(selectors) == 0 {
 		selectors = []string{"all"}
 	}
+	skipFile, configured := os.LookupEnv("PYNFS_SKIP_FILE")
+	if !configured {
+		skipFile = "pynfs_unsupported.txt"
+	}
+	skipSelectors, err := pynfsSkipSelectors(skipFile)
+	if err != nil {
+		t.Fatalf("read pynfs unsupported-test manifest: %v", err)
+	}
+	selectors = append(selectors, skipSelectors...)
 	args = append(args, selectors...)
 
 	cmd := exec.Command(python, args...)

--- a/go/nfsd/pynfs_unsupported.txt
+++ b/go/nfsd/pynfs_unsupported.txt
@@ -1,0 +1,193 @@
+# Byte-range locking is not supported. Using nolock would also exclude
+# tests of related state and error handling that remain useful.
+LKT1
+LKT2a
+LKT2d
+LKT3
+LKT4
+LKT5
+LKT6
+LKT7
+LKT8
+LKT9
+LKTOVER
+LKU1
+LKU2
+LKU3
+LKU4
+LKU5
+LKU6
+LKU6b
+LKU7
+LKU8
+LKU9
+LKU10
+LKUNONE
+LKUOVER
+LKUSPLIT
+LOCK1
+LOCK10
+LOCK11
+LOCK12a
+LOCK12b
+LOCK13
+LOCK14
+LOCK15
+LOCK16
+LOCK17
+LOCK20
+LOCK23
+LOCK24
+LOCK3
+LOCK4
+LOCK5
+LOCK6
+LOCK7
+LOCK8a
+LOCK8b
+LOCK9a
+LOCK9b
+LOCK9c
+LOCKCHGD
+LOCKCHGU
+LOCKHELD
+LOCKMRG
+LOCKRNG
+RLOWN1
+RLOWN2
+RLOWN3
+RPLY5
+RPLY6
+RPLY7
+RPLY8
+CLOSE9
+
+# OPEN_DOWNGRADE is not implemented because nfsd does not retain the
+# open share state needed to reduce an existing open. Keep the whole
+# operation together here rather than reporting NFS4ERR_NOTSUPP as ten
+# distinct protocol failures.
+OPDG1
+OPDG2
+OPDG3
+OPDG4
+OPDG5
+OPDG6
+OPDG7
+OPDG8
+OPDG10
+OPDG11
+
+# Hard links are not supported. Using nolink would also exclude tests of
+# related filehandle and error behavior that remain useful.
+LINK1a
+LINK1d
+LINK1r
+LINK2
+LINK3
+LINK4a
+LINK4r
+LINK5
+LINK6
+LINK7
+LINK9
+LINKS
+
+# TernFS does not support changing ownership or mode after creation.
+# These tests require those metadata updates either directly or as part
+# of a mixed SETATTR request.
+OPEN20
+SATT1d
+SATT1r
+SATT2a
+SATT2b
+SATT2c
+SATT13
+SATT14
+SATT15
+SATT16
+SATT17
+SATT18
+
+# NFS writes currently target a staging file for a newly created inode.
+# Existing files cannot be overwritten, requested stable-write modes are
+# not implemented, and the write path does not implement the full OPEN
+# state and share-deny model.
+OPEN2
+OPEN4
+WRT1
+WRT2
+WRT3
+WRT4
+WRT8
+WRT9
+WRT11
+WRT12
+WRT19
+
+# A newly created file is deliberately absent from its directory until
+# CLOSE streams and links the staged contents. Pynfs commonly creates a
+# file, leaves it open, and immediately resolves or mutates the
+# pathname. These tests then fail during setup with NFS4ERR_NOENT,
+# before reaching the behavior they were intended to test.
+CLOSE8
+OPEN3
+OPEN18
+OPEN21
+OPEN22
+OPEN24
+OPEN25
+OPEN26
+OPEN28
+OPEN29
+OPEN31
+RENEW3
+RDDR2
+RDDR3
+RM1r
+RNM1r
+RNM12
+RNM14
+RNM15
+RNM17
+RNM19
+RNM21
+SATT3d
+SATT6r
+SATT11r
+
+# TernFS rename primitives reject an existing destination. RNM13
+# requires atomically replacing an empty directory in the same parent.
+# Emulating that with separate REMOVE and RENAME requests could lose the
+# destination if the second request failed.
+RNM13
+
+# These retransmit the same RPC XID on the same still-open connection with
+# no intervening disconnect, and expect the original reply back from a
+# duplicate-request cache. st_replay.py's own _replay() helper says as
+# much: "no 4.0 client should really be replaying like this without
+# reconnecting first, so this test is really acting like a buggy client".
+# A real replay arrives on a new connection, quite possibly to a different
+# server behind a load balancer, so a same-connection or single-process
+# cache would not help a real client and we are not implementing one.
+# The mutations these tests replay (CREATE, CLOSE) are already idempotent
+# at the TernFS shard level independent of nfsd, which is what actually
+# protects a genuine reconnect-and-retry.
+RPLY11
+RPLY14
+
+# OPEN4_SHARE_ACCESS/DENY (share reservations) assume a single mutable
+# file that concurrent openers can contend over. TernFS has no such
+# object: a write-open constructs an independent transient file, and
+# whichever client's CLOSE (LinkFile) reaches the owning shard last wins
+# the name — see _createCurrentEdge's creation-time arbitration in
+# cpp/shard/ShardDB.cpp. There is no real conflict for share-deny bits to
+# protect, and enforcing them in nfsd's memory would only be correct on a
+# single process, which is worse than not enforcing them at all across a
+# fleet. OPEN30 verifies OPEN replay first, but its final assertion also
+# requires a new share-deny conflict, so the test cannot be separated from
+# this unsupported model. This is a permanent, deliberate gap, not a
+# backlog item.
+OPEN23
+OPEN23b
+OPEN27
+OPEN30


### PR DESCRIPTION
## Summary

Pynfs tests the NFSv4 protocol directly. It covers operation sequencing, error responses, malformed requests, replay and state handling. The existing unit and libnfs tests exercise useful client behavior, but they do not cover this part of the protocol in much depth. Pynfs is maintained by the Linux NFS project and is commonly used to test NFS server implementations.

## Details

The harness:
* Fetches the pinned pynfs-0.5 release under .deps.
* Builds its generated Python modules.
* Starts a temporary TernFS cluster and nfsd.
* Runs pynfs against that server through a tagged Go test.
* Reads pynfs's JSON results so individual failures fail the Go test.
* Retains the complete console output in pynfs.out.

Run it with:

```shell 
cd go/nfsd
make test-pynfs-cluster
```

## Results

The default run excludes broad capability classes that TernFS does not support, including sockets, FIFOs, GSS, ACLs and mode 000. Individual unsupported locking, hard-link, metadata, staging and rename cases are recorded in pynfs_unsupported.txt with the reason for each group.

An isolated baseline ran 593 non-timed tests against fresh clusters:

  - 169 passed
  - 416 failed
  - 5 crashed
  - 3 returned runner errors

The committed exclusions account for 314 of the 424 non-passing cases. The remaining 110 cases seem like real failures that will addressed in follow-up PRs.

This suite is not enabled in CI. It takes a long time and requires the full TernFS cluster.

