### PR TITLE
nfsd: validate NFS open state without share reservations

### DIFF
--- a/go/nfsd/README.md
+++ b/go/nfsd/README.md
@@ -15,6 +15,10 @@ between:
 - operations which the server must reject with the correct NFS status; and
 - NFS features which are outside the intended TernFS contract.
 
+Repeated read OPENs by one open-owner on the same file share one stateid.
+Read-to-write upgrades cannot occur because write access to an existing
+immutable file is rejected. `OPEN_DOWNGRADE` is unsupported.
+
 There are currently five test paths.
 
 Test targets ending in `-cluster` build and start a temporary TernFS cluster.

--- a/go/nfsd/clients.go
+++ b/go/nfsd/clients.go
@@ -160,6 +160,12 @@ func (cs *ClientStore) ConfirmClientID(clientID uint64) (uint64, error) {
 	return oldClientID, nil
 }
 
+func (cs *ClientStore) IsConfirmed(clientID uint64) bool {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.confirmed[clientID]
+}
+
 // maxClientIDName bounds the escaped client-id filename. It leaves headroom
 // under the advertised 255-char maxname for the ".<verifier-hex>" suffix
 // (17 chars) that pending files carry.

--- a/go/nfsd/clients.go
+++ b/go/nfsd/clients.go
@@ -163,7 +163,23 @@ func (cs *ClientStore) ConfirmClientID(clientID uint64) (uint64, error) {
 func (cs *ClientStore) IsConfirmed(clientID uint64) bool {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	return cs.confirmed[clientID]
+	if cs.confirmed[clientID] {
+		return true
+	}
+
+	// The confirmed client file outlives this ClientStore. A successful stat
+	// restores the process-local cache after nfsd restarts. Reboot replaces
+	// and unlinks the old file, so its clientid no longer resolves.
+	id := InodeID(clientID)
+	if id.Type() != InodeTypeFile {
+		return false
+	}
+	info, err := cs.fs.Stat(id)
+	if err != nil || info.Size != 8 {
+		return false
+	}
+	cs.confirmed[clientID] = true
+	return true
 }
 
 // maxClientIDName bounds the escaped client-id filename. It leaves headroom

--- a/go/nfsd/cluster_test.go
+++ b/go/nfsd/cluster_test.go
@@ -249,6 +249,30 @@ func copyStateid(dst Stateid4, src Stateid4) {
 	}
 }
 
+func confirmClusterOpen(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	fh []byte,
+	stateid Stateid4,
+) Stateid4 {
+	t.Helper()
+	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		confirmW := w.AppendArgarray_OpenConfirm()
+		copyStateid(confirmW.OpenStateid(), stateid)
+		confirmW.SetSeqid(2)
+	})
+	*xid++
+	iter := expectOK(t, res)
+	nextOp(t, &iter)
+	return nextOp(t, &iter).Value().AsOPENCONFIRM4resEntry().
+		Value().AsOPENCONFIRM4resok().OpenStateid()
+}
+
 // createFileViaNFS creates a file through the NFS protocol by doing
 // PUTROOTFH + OPEN(CREATE) + GETFH + OPEN_CONFIRM + WRITE + CLOSE.
 // Returns the file handle.
@@ -265,7 +289,7 @@ func createFileViaNFS(t *testing.T, conn net.Conn, xid *uint32, clientid uint64,
 		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
 		ownerW := ow.StartOwner()
 		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("nfstest"))
+		ownerW = ownerW.SetOwner([]byte("nfstest-" + name))
 		buf := ownerW.Finish()
 		ow.Resume(buf)
 		chw := ow.SetOpenhow_Create()
@@ -287,10 +311,6 @@ func createFileViaNFS(t *testing.T, conn net.Conn, xid *uint32, clientid uint64,
 		w.Resume(buf)
 
 		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	*xid++
 	iter := expectOK(t, res)
@@ -305,7 +325,7 @@ func createFileViaNFS(t *testing.T, conn net.Conn, xid *uint32, clientid uint64,
 	stateid := openOK.Stateid()
 
 	fh := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, xid, fh, stateid)
 
 	// WRITE
 	if len(data) > 0 {
@@ -923,10 +943,6 @@ func TestTernStagedFileGetattrAndRead(t *testing.T) {
 		w.Resume(buf)
 
 		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	xid++
 	iter := expectOK(t, res)
@@ -934,7 +950,7 @@ func TestTernStagedFileGetattrAndRead(t *testing.T) {
 	openOK := nextOp(t, &iter).Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	stateid := openOK.Stateid()
 	fh := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, &xid, fh, stateid)
 
 	// WRITE some data
 	testData := []byte("staged file content")
@@ -1285,9 +1301,6 @@ func TestTernLargeFile(t *testing.T) {
 		buf = ow.Finish()
 		w.Resume(buf)
 		w.AppendArgarray_Getfh()
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	xid++
 	iter := expectOK(t, res)
@@ -1295,7 +1308,7 @@ func TestTernLargeFile(t *testing.T) {
 	openOK := nextOp(t, &iter).Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	stateid := openOK.Stateid()
 	fh := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, &xid, fh, stateid)
 
 	// Write in chunks.
 	for off := 0; off < totalSize; off += chunkSize {
@@ -1597,10 +1610,6 @@ func TestTernNestedDirectories(t *testing.T) {
 		w.Resume(buf)
 
 		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	xid++
 	iter = expectOK(t, res)
@@ -1610,7 +1619,7 @@ func TestTernNestedDirectories(t *testing.T) {
 	openOK := nextOp(t, &iter).Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	stateid := openOK.Stateid()
 	fh := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, &xid, fh, stateid)
 
 	// Write data.
 	deepData := []byte("deep nested content")
@@ -1854,10 +1863,6 @@ func TestTernRemoveNonEmptyDir(t *testing.T) {
 		w.Resume(buf)
 
 		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	xid++
 	iter := expectOK(t, res)
@@ -1866,7 +1871,7 @@ func TestTernRemoveNonEmptyDir(t *testing.T) {
 	openOK := nextOp(t, &iter).Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	stateid := openOK.Stateid()
 	childFH := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, &xid, childFH, stateid)
 
 	// CLOSE the file.
 	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
@@ -1960,9 +1965,6 @@ func TestTernCommit(t *testing.T) {
 		buf = ow.Finish()
 		w.Resume(buf)
 		w.AppendArgarray_Getfh()
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	xid++
 	iter := expectOK(t, res)
@@ -1970,7 +1972,7 @@ func TestTernCommit(t *testing.T) {
 	openOK := nextOp(t, &iter).Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	stateid := openOK.Stateid()
 	fh := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, &xid, fh, stateid)
 
 	// WRITE with UNSTABLE4.
 	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
@@ -2210,9 +2212,6 @@ func TestTernCrossDirectoryRename(t *testing.T) {
 		w.Resume(buf)
 
 		w.AppendArgarray_Getfh()
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
 	})
 	xid++
 	iter := expectOK(t, res)
@@ -2221,7 +2220,7 @@ func TestTernCrossDirectoryRename(t *testing.T) {
 	openOK := nextOp(t, &iter).Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	stateid := openOK.Stateid()
 	fh := append([]byte(nil), nextOp(t, &iter).Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	stateid = confirmClusterOpen(t, conn, &xid, fh, stateid)
 
 	movedData := []byte("cross-dir rename data")
 	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -19,7 +19,10 @@ import (
 	"time"
 )
 
-func startTestServer(t *testing.T, dir string) (addr string, cleanup func()) {
+func startTestServer(
+	t *testing.T,
+	dir string,
+) (srv *Server, addr string, cleanup func()) {
 	t.Helper()
 	fs := NewLocalTernVFS(dir)
 	stagingDir := t.TempDir()
@@ -27,11 +30,12 @@ func startTestServer(t *testing.T, dir string) (addr string, cleanup func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer(fs, ss, nil)
+	srv, err = NewServer(fs, ss, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return serveTestServer(t, srv)
+	addr, cleanup = serveTestServer(t, srv)
+	return srv, addr, cleanup
 }
 
 func serveTestServer(t *testing.T, srv *Server) (addr string, cleanup func()) {
@@ -81,16 +85,24 @@ func sendRPC(conn net.Conn, xid uint32, proc uint32, body []byte) ([]byte, error
 	return readFrame(conn)
 }
 
-func parseRPCReply(t *testing.T, reply []byte) []byte {
-	t.Helper()
+func parseRPCReply(reply []byte) ([]byte, error) {
 	if len(reply) < 24 {
-		t.Fatalf("reply too short: %d bytes", len(reply))
+		return nil, fmt.Errorf("reply too short: %d bytes", len(reply))
 	}
 	acceptStat := binary.BigEndian.Uint32(reply[20:24])
 	if acceptStat != 0 {
-		t.Fatalf("accept_stat = %d, want SUCCESS", acceptStat)
+		return nil, fmt.Errorf("accept_stat = %d, want SUCCESS", acceptStat)
 	}
-	return reply[24:]
+	return reply[24:], nil
+}
+
+func mustParseRPCReply(t *testing.T, reply []byte) []byte {
+	t.Helper()
+	body, err := parseRPCReply(reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
 }
 
 func buildCompoundBody(tag []byte, build func(w *COMPOUND4argsWriter)) []byte {
@@ -111,41 +123,25 @@ func buildCompoundBody(tag []byte, build func(w *COMPOUND4argsWriter)) []byte {
 // sendCompound builds a compound, sends it, and returns the parsed COMPOUND4res.
 func sendCompound(t *testing.T, conn net.Conn, xid uint32, build func(w *COMPOUND4argsWriter)) COMPOUND4res {
 	t.Helper()
-	res, err := sendCompoundE(conn, xid, build)
+	body := buildCompoundBody(nil, build)
+	reply, err := sendRPC(conn, xid, procCompound, body)
 	if err != nil {
 		t.Fatal(err)
+	}
+	nfsBody, err := parseRPCReply(reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := ReadCOMPOUND4res(nfsBody)
+	if !ok {
+		t.Fatal("failed to parse COMPOUND4res")
 	}
 	return res
 }
 
-func sendCompoundE(
-	conn net.Conn,
-	xid uint32,
-	build func(w *COMPOUND4argsWriter),
-) (COMPOUND4res, error) {
-	body := buildCompoundBody(nil, build)
-	reply, err := sendRPC(conn, xid, procCompound, body)
-	if err != nil {
-		return COMPOUND4res{}, err
-	}
-	if len(reply) < 24 {
-		return COMPOUND4res{}, fmt.Errorf(
-			"RPC reply too short: %d bytes", len(reply))
-	}
-	if acceptStat := binary.BigEndian.Uint32(reply[20:24]); acceptStat != 0 {
-		return COMPOUND4res{}, fmt.Errorf(
-			"RPC accept_stat = %d, want SUCCESS", acceptStat)
-	}
-	res, ok := ReadCOMPOUND4res(reply[24:])
-	if !ok {
-		return COMPOUND4res{}, errors.New("failed to parse COMPOUND4res")
-	}
-	return res, nil
-}
-
 func TestEmptyCompound(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -159,7 +155,7 @@ func TestEmptyCompound(t *testing.T) {
 		t.Fatalf("reply xid = %d, want %d", got, xid)
 	}
 
-	res, ok := ReadCOMPOUND4res(parseRPCReply(t, reply))
+	res, ok := ReadCOMPOUND4res(mustParseRPCReply(t, reply))
 	if !ok {
 		t.Fatal("failed to parse COMPOUND4res")
 	}
@@ -176,7 +172,7 @@ func TestEmptyCompound(t *testing.T) {
 
 func TestCompoundOperationLimit(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -190,7 +186,7 @@ func TestCompoundOperationLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, ok := ReadCOMPOUND4res(parseRPCReply(t, reply))
+	res, ok := ReadCOMPOUND4res(mustParseRPCReply(t, reply))
 	if !ok {
 		t.Fatal("failed to parse COMPOUND4res")
 	}
@@ -294,7 +290,7 @@ func setupClientWithVerifier(
 
 func TestNullRPC(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -303,12 +299,12 @@ func TestNullRPC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	parseRPCReply(t, reply)
+	mustParseRPCReply(t, reply)
 }
 
 func TestProgMismatch(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -345,7 +341,7 @@ func TestProgMismatch(t *testing.T) {
 
 func TestPutrootfhGetattr(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -389,7 +385,7 @@ func TestPutrootfhGetattr(t *testing.T) {
 
 func TestPutpubfh(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -416,7 +412,7 @@ func TestLookupAndRead(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("Hello, NFS!"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -478,7 +474,7 @@ func TestReadWithOffset(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "data.txt"), []byte("0123456789abcdef"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -547,7 +543,7 @@ func TestReadEmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "empty.txt"), nil, 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -587,7 +583,7 @@ func TestReaddir(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "bbb.txt"), []byte("BB"), 0644)
 	os.Mkdir(filepath.Join(dir, "subdir"), 0755)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -636,7 +632,7 @@ func TestReaddirEmpty(t *testing.T) {
 	dir := t.TempDir()
 	os.Mkdir(filepath.Join(dir, "empty"), 0755)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -677,7 +673,7 @@ func TestPutfhRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -728,7 +724,7 @@ func TestPutfhRoundTrip(t *testing.T) {
 
 func TestPutfhBadHandle(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -753,7 +749,7 @@ func TestSavefhRestorefh(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0644)
 	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -806,7 +802,7 @@ func TestSavefhRestorefh(t *testing.T) {
 
 func TestRestorefhWithoutSave(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -825,7 +821,7 @@ func TestLookupp(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "sub"), 0755)
 	os.WriteFile(filepath.Join(dir, "root.txt"), []byte("at root"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -874,7 +870,7 @@ func TestReadlink(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "target.txt"), []byte("target"), 0644)
 	os.Symlink("target.txt", filepath.Join(dir, "link.txt"))
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -908,7 +904,7 @@ func TestReadlink(t *testing.T) {
 
 func TestAccess(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -976,7 +972,7 @@ func TestAccessMasksUnsupportedBitsByType(t *testing.T) {
 			if err := os.Symlink("file", filepath.Join(dir, "link")); err != nil {
 				t.Fatal(err)
 			}
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1014,7 +1010,7 @@ func TestOpenConfirmClose(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1046,7 +1042,7 @@ func TestOpenConfirmClose(t *testing.T) {
 
 func TestSetclientidFlow(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1143,7 +1139,7 @@ func TestClientStoreRecognizesConfirmedClientAfterRestart(t *testing.T) {
 
 func TestSetattr(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1178,7 +1174,7 @@ func TestSetattr(t *testing.T) {
 
 func TestReleaseLockowner(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1206,7 +1202,7 @@ func TestReleaseLockowner(t *testing.T) {
 
 func TestIllegalOp(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1222,7 +1218,7 @@ func TestIllegalOp(t *testing.T) {
 
 func TestUnknownOp(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1235,7 +1231,7 @@ func TestUnknownOp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, ok := ReadCOMPOUND4res(parseRPCReply(t, reply))
+	res, ok := ReadCOMPOUND4res(mustParseRPCReply(t, reply))
 	if !ok {
 		t.Fatal("failed to parse COMPOUND4res")
 	}
@@ -1257,7 +1253,7 @@ func TestUnknownOp(t *testing.T) {
 
 func TestLookupNonExistent(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1369,7 +1365,7 @@ func TestLongNamesRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1399,7 +1395,7 @@ func TestRenameInvalidNamesRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1442,7 +1438,7 @@ func TestOpenInvalidNamesRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1517,7 +1513,7 @@ func TestEmptyComponentsRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1533,7 +1529,7 @@ func TestEmptyComponentsRejected(t *testing.T) {
 
 func TestLookuppAtRootRejected(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1550,7 +1546,7 @@ func TestLookuppAtRootRejected(t *testing.T) {
 
 func TestSecinfoRequiresExistingName(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1630,7 +1626,7 @@ func TestCreateInvalidFieldsRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1695,7 +1691,7 @@ func TestCreateTypeAndAttributesValidated(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1748,7 +1744,7 @@ func TestCreateExistingNameRejected(t *testing.T) {
 			if err := test.setup(filepath.Join(dir, "existing")); err != nil {
 				t.Fatal(err)
 			}
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1800,7 +1796,7 @@ func TestOpenCreateAttributesValidated(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1861,7 +1857,7 @@ func TestCreateFromNonDirectoryRejected(t *testing.T) {
 			if err := test.setup(filepath.Join(dir, "parent")); err != nil {
 				t.Fatal(err)
 			}
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1936,7 +1932,7 @@ func TestCurrentFilehandleTypeValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2023,7 +2019,7 @@ func TestRenameDirectoryFilehandlesValidated(t *testing.T) {
 			if err := os.Symlink("file", filepath.Join(dir, "link")); err != nil {
 				t.Fatal(err)
 			}
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2090,7 +2086,7 @@ func TestOpenFilehandleTypesValidated(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2132,7 +2128,7 @@ func TestOpenFilehandleTypesValidated(t *testing.T) {
 
 func TestNoFilehandle(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2155,7 +2151,7 @@ func TestNoFilehandle(t *testing.T) {
 
 func TestCompoundStopsOnError(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2189,7 +2185,7 @@ func TestSubdirNavigation(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0755)
 	os.WriteFile(filepath.Join(dir, "a", "b", "c", "deep.txt"), []byte("deep content"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2226,7 +2222,7 @@ func TestSubdirNavigation(t *testing.T) {
 
 func TestGetattr_RootType(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2268,7 +2264,7 @@ func TestGetattr_FileSize(t *testing.T) {
 	content := []byte("twelve chars")
 	os.WriteFile(filepath.Join(dir, "sized.txt"), content, 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2312,7 +2308,7 @@ func TestGetattr_Mode(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0644)
 	os.MkdirAll(filepath.Join(dir, "d"), 0755)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2379,7 +2375,7 @@ func TestGetattr_Symlink(t *testing.T) {
 	dir := t.TempDir()
 	os.Symlink("target", filepath.Join(dir, "link"))
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2419,7 +2415,7 @@ func TestMultipleCompoundsOnConnection(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0644)
 	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2462,7 +2458,7 @@ func TestLargeFileRead(t *testing.T) {
 	}
 	os.WriteFile(filepath.Join(dir, "large.bin"), content, 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2501,7 +2497,7 @@ func TestLargeFileRead(t *testing.T) {
 
 func TestGetattr_SupportedAttrs(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2550,7 +2546,7 @@ func TestGetattr_MultipleAttrs(t *testing.T) {
 	content := []byte("test content for multi attr")
 	os.WriteFile(filepath.Join(dir, "multi.txt"), content, 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2624,7 +2620,7 @@ func TestGetattrAttributeMaskValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2669,7 +2665,7 @@ func TestVerifyAttributeMaskValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2716,7 +2712,7 @@ func finishTestFattr(w Fattr4Writer, mask [2]uint32, values []byte) []byte {
 
 func TestWriteAndRead(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2773,7 +2769,7 @@ func TestWriteAndRead(t *testing.T) {
 
 func TestStagedFileGetattrAndRead(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2873,7 +2869,7 @@ func TestOpenExistingForWriteRejected(t *testing.T) {
 	// Create an existing file.
 	os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("original"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2913,7 +2909,7 @@ func TestOpenExistingForWriteRejected(t *testing.T) {
 
 func TestCreateDirectory(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2963,7 +2959,7 @@ func TestRemoveFile(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "victim.txt"), []byte("delete me"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2998,7 +2994,7 @@ func TestRename(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "old.txt"), []byte("rename me"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3047,7 +3043,7 @@ func TestRenameToSameNameIsNoOp(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(dir, "same"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3081,7 +3077,7 @@ func TestRenameToSameNameIsNoOp(t *testing.T) {
 
 func TestDelegpurgeNotSupported(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3100,7 +3096,7 @@ func TestLinkNotSupported(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("test"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3126,7 +3122,7 @@ func TestCreateSymlink(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "target.txt"), []byte("target"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3176,7 +3172,7 @@ func TestCreateSymlink(t *testing.T) {
 
 func TestMinorVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3195,7 +3191,7 @@ func TestMinorVersionMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nfsBody := parseRPCReply(t, reply)
+	nfsBody := mustParseRPCReply(t, reply)
 	res, ok := ReadCOMPOUND4res(nfsBody)
 	if !ok {
 		t.Fatal("failed to parse COMPOUND4res")
@@ -3208,7 +3204,7 @@ func TestMinorVersionMismatch(t *testing.T) {
 
 func TestCreateEmptyFile(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3262,6 +3258,28 @@ func confirmOpenState(
 	return confirmed
 }
 
+func openConfirmStatus(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	fh []byte,
+	seq uint32,
+	stateid [16]byte,
+) uint32 {
+	t.Helper()
+	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		confirm := w.AppendArgarray_OpenConfirm()
+		setStateid(confirm.OpenStateid(), stateid)
+		confirm.SetSeqid(seq)
+	})
+	*xid++
+	return res.Status()
+}
+
 func setStateid(dst Stateid4, stateid [16]byte) {
 	dst.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
 	for i := range 12 {
@@ -3301,7 +3319,7 @@ func openFileForOwnerE(
 	create bool,
 	guarded bool,
 ) (status uint32, stateid [16]byte, fh []byte, rflags uint32, err error) {
-	res, err := sendCompoundE(conn, *xid, func(w *COMPOUND4argsWriter) {
+	body := buildCompoundBody(nil, func(w *COMPOUND4argsWriter) {
 		w.AppendArgarray_Putrootfh()
 		ow := w.AppendArgarray_Open()
 		ow.SetSeqid(seq)
@@ -3337,9 +3355,19 @@ func openFileForOwnerE(
 		w.Resume(ow.Finish())
 		w.AppendArgarray_Getfh()
 	})
+	reply, err := sendRPC(conn, *xid, procCompound, body)
 	*xid++
 	if err != nil {
 		return 0, stateid, nil, 0, err
+	}
+	nfsBody, err := parseRPCReply(reply)
+	if err != nil {
+		return 0, stateid, nil, 0, err
+	}
+	res, ok := ReadCOMPOUND4res(nfsBody)
+	if !ok {
+		return 0, stateid, nil, 0,
+			errors.New("failed to parse COMPOUND4res")
 	}
 	if res.Status() != NFS4_OK {
 		return res.Status(), stateid, nil, 0, nil
@@ -3426,7 +3454,7 @@ func closeFileWithSeqStatusE(
 	stateid [16]byte,
 	seq uint32,
 ) (uint32, error) {
-	res, err := sendCompoundE(conn, *xid, func(w *COMPOUND4argsWriter) {
+	body := buildCompoundBody(nil, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
 		fhW := pw.StartObject()
 		buf := fhW.SetData(fh).Finish()
@@ -3437,9 +3465,18 @@ func closeFileWithSeqStatusE(
 		caw.SetSeqid(seq)
 		setStateid(caw.OpenStateid(), stateid)
 	})
+	reply, err := sendRPC(conn, *xid, procCompound, body)
 	*xid++
 	if err != nil {
 		return 0, err
+	}
+	nfsBody, err := parseRPCReply(reply)
+	if err != nil {
+		return 0, err
+	}
+	res, ok := ReadCOMPOUND4res(nfsBody)
+	if !ok {
+		return 0, errors.New("failed to parse COMPOUND4res")
 	}
 	return res.Status(), nil
 }
@@ -3539,7 +3576,7 @@ func TestReaddirPagination(t *testing.T) {
 	}
 	sort.Strings(expected)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3574,7 +3611,7 @@ func TestReaddirCookieverfMismatch(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3640,7 +3677,7 @@ func TestReaddirReservedCookies(t *testing.T) {
 	for _, cookie := range []uint64{1, 2} {
 		t.Run(fmt.Sprintf("cookie_%d", cookie), func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -3666,7 +3703,7 @@ func TestReaddirReservedCookies(t *testing.T) {
 
 func TestReaddirWriteOnlyAttributesRejected(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3693,7 +3730,7 @@ func TestReaddirTooSmall(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3722,7 +3759,7 @@ func TestReaddirNfsDirHidden(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "visible.txt"), []byte("x"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3761,7 +3798,7 @@ func TestReaddirTransientNotVisible(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("x"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3811,7 +3848,7 @@ func TestSetattrTime(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3875,7 +3912,7 @@ func TestSetattrModeRejected(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3964,7 +4001,7 @@ func TestSetattrValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			addr, cleanup := startTestServer(t, dir)
+			_, addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -4001,7 +4038,7 @@ func TestSetattrValidation(t *testing.T) {
 
 func TestSetattrSize(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4083,7 +4120,7 @@ func TestSetattrSize(t *testing.T) {
 func TestSetattrSizeRequiresWriteOpen(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4120,7 +4157,7 @@ func TestSetattrSizeRequiresWriteOpen(t *testing.T) {
 
 func TestOpenExclusive4Rejected(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4163,7 +4200,7 @@ func TestOpenClaimPrevious(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4198,7 +4235,7 @@ func TestOpenRflagsRequireConfirm(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4243,7 +4280,7 @@ func TestOpenConfirmReplay(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4269,9 +4306,52 @@ func TestOpenConfirmReplay(t *testing.T) {
 	}
 }
 
+func TestOpenConfirmOldStateidAdvancesSeqid(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "file.txt"), []byte("data"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, stateid, fh, _ := openFileForOwner(
+		t, conn, &xid, clientID, "owner", 1, "file.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	old := stateid
+	binary.BigEndian.PutUint32(old[:4], 0)
+	if status := openConfirmStatus(
+		t, conn, &xid, fh, 2, old,
+	); status != NFS4ERR_OLD_STATEID {
+		t.Fatalf("old OPEN_CONFIRM = %s, want NFS4ERR_OLD_STATEID",
+			Nfsstat4Name(status))
+	}
+	if status := openConfirmStatus(
+		t, conn, &xid, fh, 2, stateid,
+	); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("reused OPEN_CONFIRM seqid = %s, want NFS4ERR_BAD_SEQID",
+			Nfsstat4Name(status))
+	}
+	confirmed := confirmOpenState(t, conn, &xid, fh, 3, stateid)
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, confirmed, 4,
+	); status != NFS4_OK {
+		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
+	}
+}
+
 func TestCloseReplay(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4302,7 +4382,7 @@ func TestFailedOpenAdvancesOwnerSeqid(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4357,7 +4437,7 @@ func TestOnlyFirstOpenRequiresConfirmation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4397,22 +4477,14 @@ func TestOnlyFirstOpenRequiresConfirmation(t *testing.T) {
 	}
 }
 
-func TestOpenUpgradeReusesState(t *testing.T) {
+func TestReopenReusesState(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(
 		filepath.Join(dir, "file.txt"), []byte("data"), 0644,
 	); err != nil {
 		t.Fatal(err)
 	}
-	staging, err := NewLocalStagingStore(t.TempDir(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv, err := NewServer(NewLocalTernVFS(dir), staging, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr, cleanup := serveTestServer(t, srv)
+	srv, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4428,6 +4500,9 @@ func TestOpenUpgradeReusesState(t *testing.T) {
 			Nfsstat4Name(status), flags)
 	}
 	first = confirmOpenState(t, conn, &xid, fh, 2, first)
+	if got := binary.BigEndian.Uint32(first[:4]); got != 2 {
+		t.Fatalf("confirmed OPEN generation = %d, want 2", got)
+	}
 
 	status, upgraded, upgradedFH, flags := openFileForOwner(
 		t, conn, &xid, clientID, "shared-owner", 3, "file.txt",
@@ -4449,6 +4524,21 @@ func TestOpenUpgradeReusesState(t *testing.T) {
 	if !bytes.Equal(upgradedFH, fh) {
 		t.Fatal("second OPEN returned a different filehandle")
 	}
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		rw := w.AppendArgarray_Read()
+		setStateid(rw.Stateid(), first)
+		rw.SetOffset(0)
+		rw.SetCount(1)
+	})
+	xid++
+	if res.Status() != NFS4ERR_OLD_STATEID {
+		t.Fatalf("READ with generation 2 = %s, want NFS4ERR_OLD_STATEID",
+			Nfsstat4Name(res.Status()))
+	}
 	if status := closeFileWithSeqStatus(
 		t, conn, &xid, fh, upgraded, 4,
 	); status != NFS4_OK {
@@ -4459,6 +4549,17 @@ func TestOpenUpgradeReusesState(t *testing.T) {
 	if len(srv.opens.states) != 0 {
 		t.Fatalf("states after CLOSE = %d, want 0", len(srv.opens.states))
 	}
+	owner := srv.opens.owners[openOwnerKey{
+		clientID: clientID,
+		owner:    "shared-owner",
+	}]
+	if owner == nil {
+		t.Fatal("open owner was removed after CLOSE")
+	}
+	if len(owner.states) != 0 {
+		t.Fatalf("owner states after CLOSE = %d, want 0",
+			len(owner.states))
+	}
 }
 
 func TestReadCloseAfterFileRemoval(t *testing.T) {
@@ -4467,15 +4568,7 @@ func TestReadCloseAfterFileRemoval(t *testing.T) {
 	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	staging, err := NewLocalStagingStore(t.TempDir(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv, err := NewServer(NewLocalTernVFS(dir), staging, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr, cleanup := serveTestServer(t, srv)
+	srv, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4499,6 +4592,48 @@ func TestReadCloseAfterFileRemoval(t *testing.T) {
 	}
 }
 
+func TestWriteCloseWithoutStagingExpiresAndDropsState(t *testing.T) {
+	dir := t.TempDir()
+	srv, addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	stateid, fh := openCreateFile(
+		t, conn, &xid, clientID, "lost.txt")
+	fileID, ok := fhToInodeID(fh)
+	if !ok {
+		t.Fatal("invalid filehandle returned by OPEN")
+	}
+	srv.stagingStore.Remove(fileID)
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 3,
+	); status != NFS4ERR_EXPIRED {
+		t.Fatalf("CLOSE without staging = %s, want NFS4ERR_EXPIRED",
+			Nfsstat4Name(status))
+	}
+
+	srv.opens.mu.Lock()
+	defer srv.opens.mu.Unlock()
+	if len(srv.opens.states) != 0 {
+		t.Fatalf("states after expired CLOSE = %d, want 0",
+			len(srv.opens.states))
+	}
+	owner := srv.opens.owners[openOwnerKey{
+		clientID: clientID,
+		owner:    "test-owner-lost.txt",
+	}]
+	if owner == nil {
+		t.Fatal("open owner was removed after expired CLOSE")
+	}
+	if len(owner.states) != 0 {
+		t.Fatalf("owner states after expired CLOSE = %d, want 0",
+			len(owner.states))
+	}
+}
+
 func TestUnconfirmedOwnerOutOfSequenceOpen(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(
@@ -4506,16 +4641,8 @@ func TestUnconfirmedOwnerOutOfSequenceOpen(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	fs := NewLocalTernVFS(dir)
-	staging, err := NewLocalStagingStore(t.TempDir(), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	srv, err := NewServer(fs, staging, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr, cleanup := serveTestServer(t, srv)
+	srv, addr, cleanup := startTestServer(t, dir)
+	staging := srv.stagingStore.(*LocalStagingStore)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4562,6 +4689,66 @@ func TestUnconfirmedOwnerOutOfSequenceOpen(t *testing.T) {
 	second = confirmOpenState(t, conn, &xid, secondFH, 8, second)
 	if status := closeFileWithSeqStatus(
 		t, conn, &xid, secondFH, second, 9,
+	); status != NFS4_OK {
+		t.Fatalf("replacement CLOSE = %s", Nfsstat4Name(status))
+	}
+}
+
+func TestUnconfirmedOwnerInSequenceOpen(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "second.txt"), []byte("data"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	srv, addr, cleanup := startTestServer(t, dir)
+	staging := srv.stagingStore.(*LocalStagingStore)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, first, firstFH, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 1, "first.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK || flags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatalf("first OPEN status = %s, rflags = %#x",
+			Nfsstat4Name(status), flags)
+	}
+	firstID, ok := fhToInodeID(firstFH)
+	if !ok {
+		t.Fatal("invalid filehandle returned by first OPEN")
+	}
+	if staging.Get(firstID) == nil {
+		t.Fatal("first OPEN did not create staging")
+	}
+
+	status, second, secondFH, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 2, "second.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("in-sequence OPEN = %s, want NFS4_OK",
+			Nfsstat4Name(status))
+	}
+	if flags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatal("replacement OPEN did not require confirmation")
+	}
+	if staging.Get(firstID) != nil {
+		t.Fatal("replacement OPEN retained abandoned staging")
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, firstFH, first, 3,
+	); status != NFS4ERR_BAD_STATEID {
+		t.Fatalf("abandoned stateid CLOSE = %s, want NFS4ERR_BAD_STATEID",
+			Nfsstat4Name(status))
+	}
+
+	second = confirmOpenState(t, conn, &xid, secondFH, 3, second)
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, secondFH, second, 4,
 	); status != NFS4_OK {
 		t.Fatalf("replacement CLOSE = %s", Nfsstat4Name(status))
 	}
@@ -4627,6 +4814,17 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 	defer secondConn.Close()
 	xid := uint32(1)
 	clientID := setupClient(t, firstConn, &xid)
+	secondRequestEntered := make(chan struct{})
+	var startMu sync.Mutex
+	startCalls := 0
+	srv.beforeStartOpen = func() {
+		startMu.Lock()
+		defer startMu.Unlock()
+		startCalls++
+		if startCalls == 2 {
+			close(secondRequestEntered)
+		}
+	}
 
 	type result struct {
 		status  uint32
@@ -4635,7 +4833,6 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 		err     error
 	}
 	results := make(chan result, 2)
-	secondStarted := make(chan struct{})
 	open := func(conn net.Conn, xid uint32) {
 		status, stateid, fh, _, err := openFileForOwnerE(
 			conn, &xid, clientID, "shared-owner", 1, "race.txt",
@@ -4647,11 +4844,8 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 	}
 	go open(firstConn, 100)
 	<-fs.firstEntered
-	go func() {
-		close(secondStarted)
-		open(secondConn, 200)
-	}()
-	<-secondStarted
+	go open(secondConn, 200)
+	<-secondRequestEntered
 	close(fs.releaseFirst)
 	first := <-results
 	second := <-results
@@ -4704,6 +4898,7 @@ type blockingFailingLinkVFS struct {
 	TernVFS
 	entered chan struct{}
 	release chan struct{}
+	once    sync.Once
 }
 
 func (fs *blockingFailingLinkVFS) LinkFile(
@@ -4713,7 +4908,7 @@ func (fs *blockingFailingLinkVFS) LinkFile(
 	string,
 	io.Reader,
 ) error {
-	close(fs.entered)
+	fs.once.Do(func() { close(fs.entered) })
 	<-fs.release
 	return errors.New("injected LinkFile failure")
 }
@@ -4739,13 +4934,11 @@ func (store *notifyingStagingStore) GetMeta(
 	return store.StagingStore.GetMeta(id)
 }
 
-func (store *notifyingStagingStore) notifyOnGetMeta(
-	call int,
-) <-chan struct{} {
+func (store *notifyingStagingStore) notifyNextGetMeta() <-chan struct{} {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 	store.calls = 0
-	store.notifyAt = call
+	store.notifyAt = 1
 	store.notified = make(chan struct{})
 	return store.notified
 }
@@ -4783,10 +4976,6 @@ func TestWaitingCloseRechecksStagingMeta(t *testing.T) {
 	}
 	stateid = confirmOpenState(t, firstConn, &xid, fh, 2, stateid)
 
-	// The first CLOSE reads metadata twice before entering LinkFile. The
-	// third read proves the second CLOSE captured its recovery hint before
-	// waiting for the owner operation.
-	secondRead := staging.notifyOnGetMeta(3)
 	firstResult := make(chan closeResult, 1)
 	go func() {
 		closeXID := uint32(100)
@@ -4795,6 +4984,7 @@ func TestWaitingCloseRechecksStagingMeta(t *testing.T) {
 		firstResult <- closeResult{status: status, err: err}
 	}()
 	<-fs.entered
+	secondRead := staging.notifyNextGetMeta()
 	secondResult := make(chan closeResult, 1)
 	go func() {
 		closeXID := uint32(200)
@@ -4910,10 +5100,11 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 			releaseFirst: make(chan struct{}),
 		},
 	}
-	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	localStaging, err := NewLocalStagingStore(t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	staging := &notifyingStagingStore{StagingStore: localStaging}
 	srv, err := NewServer(fs, staging, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -4944,15 +5135,14 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 		results <- closeResult{status: status, err: err}
 	}()
 	<-fs.firstEntered
-	secondStarted := make(chan struct{})
+	secondRequestEntered := staging.notifyNextGetMeta()
 	go func() {
-		close(secondStarted)
 		closeXID := uint32(200)
 		status, err := closeFileWithSeqStatusE(
 			secondConn, &closeXID, fh, stateid, 3)
 		results <- closeResult{status: status, err: err}
 	}()
-	<-secondStarted
+	<-secondRequestEntered
 	close(fs.releaseFirst)
 	first := <-results
 	second := <-results
@@ -4971,7 +5161,7 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 
 func TestCloseUnknownStateid(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4992,7 +5182,7 @@ func TestCloseUnknownStateid(t *testing.T) {
 
 func TestWriteBadStateid(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5038,7 +5228,7 @@ func TestWriteBadStateid(t *testing.T) {
 // fallback — may legitimately omit a real stateid on WRITE.
 func TestWriteSpecialStateid(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5084,7 +5274,7 @@ func TestWriteSpecialStateid(t *testing.T) {
 // nfs4lib.setattr default stateid is the anonymous one.
 func TestSetattrSizeSpecialStateid(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5138,7 +5328,7 @@ func TestSetattrSizeSpecialStateid(t *testing.T) {
 
 func TestCommitVerifier(t *testing.T) {
 	dir := t.TempDir()
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5268,7 +5458,7 @@ func TestLockNotSupported(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5307,8 +5497,34 @@ func TestLockNotSupported(t *testing.T) {
 	}
 }
 
+func TestOpenOwnerSeqidWrapsToOne(t *testing.T) {
+	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
+	owner := openOwnerKey{clientID: 1, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state, status := store.addOpen(
+		owner, ^uint32(0), fileID, false, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		state.id, 1, fileID, 1,
+	); status != NFS4_OK {
+		t.Fatalf("OPEN_CONFIRM seqid 1 = %s, want NFS4_OK",
+			Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		state.id, 1, fileID, 0,
+	); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("OPEN_CONFIRM seqid 0 = %s, want NFS4ERR_BAD_SEQID",
+			Nfsstat4Name(status))
+	}
+}
+
 func TestOpenStateStoreCloseChecksSeqidBeforeStateid(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 7, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	state := addConfirmedOpen(t, store, owner, fileID)
@@ -5322,6 +5538,7 @@ func TestOpenStateStoreCloseChecksSeqidBeforeStateid(t *testing.T) {
 
 func TestOpenStateStoreLookupClassifiesStateids(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 7, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	state := addConfirmedOpen(t, store, owner, fileID)
@@ -5347,6 +5564,7 @@ func TestOpenStateStoreLookupClassifiesStateids(t *testing.T) {
 
 func TestOpenStateStoreReplay(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	owner := openOwnerKey{clientID: 1, owner: "first"}
 	if _, replay, status := store.beginOpen(owner, 4); status != NFS4_OK || replay {
@@ -5390,6 +5608,7 @@ func TestOpenStateStoreReplay(t *testing.T) {
 
 func TestOpenStateStoreNonExemptCloseErrorAdvancesSeqid(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 1, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	state := addConfirmedOpen(t, store, owner, fileID)
@@ -5413,6 +5632,7 @@ func TestOpenStateStoreNonExemptCloseErrorAdvancesSeqid(t *testing.T) {
 
 func TestOpenStateStoreExemptErrorDoesNotAdvance(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 1, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	state, status := store.addOpen(
@@ -5441,6 +5661,7 @@ func TestOpenStateStoreExemptErrorDoesNotAdvance(t *testing.T) {
 
 func TestOpenStateStoreDisposesClosedStateAndBoundsOwnerReplay(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 1, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	state, status := store.addOpen(
@@ -5479,6 +5700,7 @@ func TestOpenStateStoreDisposesClosedStateAndBoundsOwnerReplay(t *testing.T) {
 
 func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	clientID := uint64(1)
 	var states []openState
 	for i, name := range []string{"user-a", "user-b"} {
@@ -5519,6 +5741,7 @@ func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
 
 func TestPurgeClientReturnsOnlyWriteFiles(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	clientID := uint64(1)
 	readID := MakeInodeID(InodeTypeFile, 1)
 	writeID := MakeInodeID(InodeTypeFile, 2)
@@ -5556,6 +5779,7 @@ func TestPurgeClientReturnsOnlyWriteFiles(t *testing.T) {
 
 func TestOpenStateStoreBoundsRebootTombstones(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	var firstStateID StateID
 	for i := 0; i <= maxTombstones; i++ {
@@ -5590,6 +5814,7 @@ func TestOpenStateStoreBoundsRebootTombstones(t *testing.T) {
 
 func TestRecoveredCloseOperationsAreStateidScoped(t *testing.T) {
 	store := newOpenStateStore()
+	defer assertOpenStateIndex(t, store)
 	var firstID, secondID StateID
 	binary.BigEndian.PutUint32(firstID[0:4], store.epoch+1)
 	binary.BigEndian.PutUint32(secondID[0:4], store.epoch+1)
@@ -5887,7 +6112,7 @@ func TestSetclientidRebootRemovesStagingFiles(t *testing.T) {
 func TestSetclientidReboot(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
-	addr, cleanup := startTestServer(t, dir)
+	_, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -982,84 +982,30 @@ func TestOpenConfirmClose(t *testing.T) {
 
 	xid := uint32(1)
 	clientid := setupClient(t, conn, &xid)
+	stateid, fh := openReadFile(t, conn, &xid, clientid, "file.txt")
 
-	// PUTROOTFH + OPEN(file.txt) + OPEN_CONFIRM + GETFH + READ + CLOSE
 	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_READ)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		ow.SetOpenhow_Default(OPEN4_NOCREATE)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte("file.txt")).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
-
-		w.AppendArgarray_Getfh()
-
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
 		rw := w.AppendArgarray_Read()
-		rw.Stateid().SetSeqid(0)
+		rw.Stateid().SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
+		for i := 0; i < 12; i++ {
+			rw.Stateid().SetOther(i, stateid[4+i])
+		}
 		rw.SetOffset(0)
 		rw.SetCount(1024)
-
-		caw := w.AppendArgarray_Close()
-		caw.SetSeqid(3)
-		caw.OpenStateid().SetSeqid(1)
 	})
-
+	xid++
 	iter := expectOK(t, res)
-	if res.ResarrayCount() != 6 {
-		t.Fatalf("resarray count = %d, want 6", res.ResarrayCount())
-	}
-
-	nextOp(t, &iter) // PUTROOTFH
-
-	// OPEN
+	nextOp(t, &iter)
 	entry := nextOp(t, &iter)
-	openRes := entry.Value().AsOPEN4resEntry()
-	if openRes.Disc() != NFS4_OK {
-		t.Fatalf("OPEN status = %d", openRes.Disc())
-	}
-
-	// OPEN_CONFIRM
-	entry = nextOp(t, &iter)
-	ocRes := entry.Value().AsOPENCONFIRM4resEntry()
-	if ocRes.Disc() != NFS4_OK {
-		t.Fatalf("OPEN_CONFIRM status = %d", ocRes.Disc())
-	}
-
-	// GETFH
-	entry = nextOp(t, &iter)
-	fh := entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()
-	if len(fh) != 8 {
-		t.Fatalf("FH = %d bytes, want 8", len(fh))
-	}
-
-	// READ
-	entry = nextOp(t, &iter)
 	readOk := entry.Value().AsREAD4resEntry().Value().AsREAD4resok()
 	if string(readOk.Data()) != "content" {
 		t.Fatalf("READ = %q, want %q", readOk.Data(), "content")
 	}
-
-	// CLOSE
-	entry = nextOp(t, &iter)
-	closeRes := entry.Value().AsCLOSE4resEntry()
-	if closeRes.Disc() != NFS4_OK {
-		t.Fatalf("CLOSE status = %d", closeRes.Disc())
-	}
+	closeFile(t, conn, &xid, fh, stateid)
 }
 
 func TestSetclientidFlow(t *testing.T) {
@@ -2718,68 +2664,13 @@ func TestWriteAndRead(t *testing.T) {
 
 	xid := uint32(1)
 	clientid := setupClient(t, conn, &xid)
-
-	// PUTROOTFH + OPEN(CREATE) + OPEN_CONFIRM
-	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_BOTH)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		// OPEN4_CREATE with UNCHECKED4 and empty attrs.
-		chw := ow.SetOpenhow_Create()
-		faw := chw.SetValue_Unchecked4()
-		bmW := faw.StartAttrmask()
-		buf = bmW.Finish()
-		faw.Resume(buf)
-		alW := faw.StartAttrVals()
-		buf = alW.SetData(nil).Finish()
-		faw.Resume(buf)
-		buf = faw.Finish()
-		chw.Resume(buf)
-		buf = chw.Finish()
-		ow.Resume(buf)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte("newfile.txt")).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-
-		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
-	})
-	xid++
-
-	iter := expectOK(t, res)
-	nextOp(t, &iter) // PUTROOTFH
-
-	// Get the stateid from OPEN.
-	entry := nextOp(t, &iter)
-	openRes := entry.Value().AsOPEN4resEntry()
-	if openRes.Disc() != NFS4_OK {
-		t.Fatalf("OPEN status = %d", openRes.Disc())
-	}
-	openOk := openRes.Value().AsOPEN4resok()
-	openStateid := openOk.Stateid()
-
-	// Get the filehandle from GETFH (file is transient, not yet in directory).
-	entry = nextOp(t, &iter)
-	fh := append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-
-	nextOp(t, &iter) // OPEN_CONFIRM
+	openStateid, fh := openCreateFile(
+		t, conn, &xid, clientid, "newfile.txt",
+	)
 
 	// WRITE to the file.
 	writeData := []byte("hello world from NFS write!")
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
 		fhW := pw.StartObject()
 		buf := fhW.SetData(fh).Finish()
@@ -2789,9 +2680,9 @@ func TestWriteAndRead(t *testing.T) {
 
 		ww := w.AppendArgarray_Write()
 		sid := ww.Stateid()
-		sid.SetSeqid(openStateid.Seqid())
+		sid.SetSeqid(binary.BigEndian.Uint32(openStateid[0:4]))
 		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid.Other(i))
+			sid.SetOther(i, openStateid[4+i])
 		}
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(2) // FILE_SYNC4
@@ -2801,9 +2692,9 @@ func TestWriteAndRead(t *testing.T) {
 	})
 	xid++
 
-	iter = expectOK(t, res)
+	iter := expectOK(t, res)
 	nextOp(t, &iter) // PUTFH
-	entry = nextOp(t, &iter)
+	entry := nextOp(t, &iter)
 	writeRes := entry.Value().AsWRITE4resEntry()
 	if writeRes.Disc() != NFS4_OK {
 		t.Fatalf("WRITE status = %d", writeRes.Disc())
@@ -2813,25 +2704,7 @@ func TestWriteAndRead(t *testing.T) {
 		t.Fatalf("WRITE count = %d, want %d", writeOk.Count(), len(writeData))
 	}
 
-	// CLOSE to commit the file.
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		pw := w.AppendArgarray_Putfh()
-		fhW := pw.StartObject()
-		buf := fhW.SetData(fh).Finish()
-		pw.Resume(buf)
-		buf = pw.Finish()
-		w.Resume(buf)
-
-		caw := w.AppendArgarray_Close()
-		caw.SetSeqid(3)
-		sid := caw.OpenStateid()
-		sid.SetSeqid(openStateid.Seqid())
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid.Other(i))
-		}
-	})
-	xid++
-	expectOK(t, res)
+	closeFile(t, conn, &xid, fh, openStateid)
 
 	// Verify the file was written to disk.
 	data, err := os.ReadFile(filepath.Join(dir, "newfile.txt"))
@@ -2852,58 +2725,13 @@ func TestStagedFileGetattrAndRead(t *testing.T) {
 
 	xid := uint32(1)
 	clientid := setupClient(t, conn, &xid)
-
-	// Create and open a new file for write.
-	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_BOTH)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		chw := ow.SetOpenhow_Create()
-		faw := chw.SetValue_Unchecked4()
-		bmW := faw.StartAttrmask()
-		buf = bmW.Finish()
-		faw.Resume(buf)
-		alW := faw.StartAttrVals()
-		buf = alW.SetData(nil).Finish()
-		faw.Resume(buf)
-		buf = faw.Finish()
-		chw.Resume(buf)
-		buf = chw.Finish()
-		ow.Resume(buf)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte("staged.txt")).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-
-		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
-	})
-	xid++
-
-	iter := expectOK(t, res)
-	nextOp(t, &iter) // PUTROOTFH
-	entry := nextOp(t, &iter)
-	openOk := entry.Value().AsOPEN4resEntry().Value().AsOPEN4resok()
-	openStateid := openOk.Stateid()
-	entry = nextOp(t, &iter) // GETFH
-	fh := append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
+	openStateid, fh := openCreateFile(
+		t, conn, &xid, clientid, "staged.txt",
+	)
 
 	// Write some data using the open stateid.
 	writeData := []byte("staged content here!")
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
 		fhW := pw.StartObject()
 		buf := fhW.SetData(fh).Finish()
@@ -2913,9 +2741,9 @@ func TestStagedFileGetattrAndRead(t *testing.T) {
 
 		ww := w.AppendArgarray_Write()
 		sid := ww.Stateid()
-		sid.SetSeqid(openStateid.Seqid())
+		sid.SetSeqid(binary.BigEndian.Uint32(openStateid[0:4]))
 		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid.Other(i))
+			sid.SetOther(i, openStateid[4+i])
 		}
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(2)
@@ -2945,9 +2773,9 @@ func TestStagedFileGetattrAndRead(t *testing.T) {
 	})
 	xid++
 
-	iter = expectOK(t, res)
+	iter := expectOK(t, res)
 	nextOp(t, &iter) // PUTFH
-	entry = nextOp(t, &iter)
+	entry := nextOp(t, &iter)
 	getattrOk := entry.Value().AsGETATTR4resEntry().Value().AsGETATTR4resok()
 	attrData := getAttrData(t, getattrOk)
 	if len(attrData) < 8 {
@@ -2986,25 +2814,7 @@ func TestStagedFileGetattrAndRead(t *testing.T) {
 		t.Fatalf("READ data = %q, want %q", readData, writeData)
 	}
 
-	// Close the file.
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		pw := w.AppendArgarray_Putfh()
-		fhW := pw.StartObject()
-		buf := fhW.SetData(fh).Finish()
-		pw.Resume(buf)
-		buf = pw.Finish()
-		w.Resume(buf)
-
-		caw := w.AppendArgarray_Close()
-		caw.SetSeqid(3)
-		sid := caw.OpenStateid()
-		sid.SetSeqid(openStateid.Seqid())
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid.Other(i))
-		}
-	})
-	xid++
-	expectOK(t, res)
+	closeFile(t, conn, &xid, fh, openStateid)
 }
 
 func TestOpenExistingForWriteRejected(t *testing.T) {
@@ -3354,78 +3164,10 @@ func TestCreateEmptyFile(t *testing.T) {
 
 	xid := uint32(1)
 	clientid := setupClient(t, conn, &xid)
-
-	// PUTROOTFH + OPEN(CREATE) + OPEN_CONFIRM
-	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_BOTH)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		chw := ow.SetOpenhow_Create()
-		faw := chw.SetValue_Unchecked4()
-		bmW := faw.StartAttrmask()
-		buf = bmW.Finish()
-		faw.Resume(buf)
-		alW := faw.StartAttrVals()
-		buf = alW.SetData(nil).Finish()
-		faw.Resume(buf)
-		buf = faw.Finish()
-		chw.Resume(buf)
-		buf = chw.Finish()
-		ow.Resume(buf)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte("empty.txt")).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-
-		w.AppendArgarray_Getfh()
-
-		ocw := w.AppendArgarray_OpenConfirm()
-		ocw.OpenStateid().SetSeqid(1)
-		ocw.SetSeqid(2)
-	})
-	xid++
-
-	iter := expectOK(t, res)
-	nextOp(t, &iter) // PUTROOTFH
-	entry := nextOp(t, &iter)
-	openRes := entry.Value().AsOPEN4resEntry()
-	if openRes.Disc() != NFS4_OK {
-		t.Fatalf("OPEN status = %d", openRes.Disc())
-	}
-	openOk := openRes.Value().AsOPEN4resok()
-	openStateid := openOk.Stateid()
-	entry = nextOp(t, &iter) // GETFH
-	fh := append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
-	nextOp(t, &iter) // OPEN_CONFIRM
-
-	// CLOSE immediately without writing anything.
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		pw := w.AppendArgarray_Putfh()
-		fhW := pw.StartObject()
-		buf := fhW.SetData(fh).Finish()
-		pw.Resume(buf)
-		buf = pw.Finish()
-		w.Resume(buf)
-
-		caw := w.AppendArgarray_Close()
-		caw.SetSeqid(3)
-		sid := caw.OpenStateid()
-		sid.SetSeqid(openStateid.Seqid())
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid.Other(i))
-		}
-	})
-	xid++
-	expectOK(t, res)
+	openStateid, fh := openCreateFile(
+		t, conn, &xid, clientid, "empty.txt",
+	)
+	closeFile(t, conn, &xid, fh, openStateid)
 
 	// Verify the empty file was created on disk.
 	data, err := os.ReadFile(filepath.Join(dir, "empty.txt"))
@@ -3435,6 +3177,42 @@ func TestCreateEmptyFile(t *testing.T) {
 	if len(data) != 0 {
 		t.Fatalf("file content = %q, want empty", data)
 	}
+}
+
+func confirmOpenState(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	fh []byte,
+	seqid uint32,
+	stateid [16]byte,
+) [16]byte {
+	t.Helper()
+	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		confirmW := w.AppendArgarray_OpenConfirm()
+		sid := confirmW.OpenStateid()
+		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
+		for i := 0; i < 12; i++ {
+			sid.SetOther(i, stateid[4+i])
+		}
+		confirmW.SetSeqid(seqid)
+	})
+	*xid++
+	iter := expectOK(t, res)
+	nextOp(t, &iter)
+	entry := nextOp(t, &iter)
+	sid := entry.Value().AsOPENCONFIRM4resEntry().
+		Value().AsOPENCONFIRM4resok().OpenStateid()
+	var confirmed [16]byte
+	binary.BigEndian.PutUint32(confirmed[0:4], sid.Seqid())
+	for i := 0; i < 12; i++ {
+		confirmed[4+i] = sid.Other(i)
+	}
+	return confirmed
 }
 
 // openReadFile opens a file for read and returns the open stateid and filehandle.
@@ -3448,7 +3226,7 @@ func openReadFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, fil
 		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
 		ownerW := ow.StartOwner()
 		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
+		ownerW = ownerW.SetOwner([]byte("test-owner-" + filename))
 		buf := ownerW.Finish()
 		ow.Resume(buf)
 		ow.SetOpenhow_Default(OPEN4_NOCREATE)
@@ -3475,6 +3253,7 @@ func openReadFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, fil
 	}
 	entry = nextOp(t, &iter)
 	fh = append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
+	stateid = confirmOpenState(t, conn, xid, fh, 2, stateid)
 	return stateid, fh
 }
 
@@ -3489,7 +3268,7 @@ func openCreateFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, f
 		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
 		ownerW := ow.StartOwner()
 		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
+		ownerW = ownerW.SetOwner([]byte("test-owner-" + filename))
 		buf := ownerW.Finish()
 		ow.Resume(buf)
 		chw := ow.SetOpenhow_Create()
@@ -3527,6 +3306,7 @@ func openCreateFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, f
 	}
 	entry = nextOp(t, &iter)
 	fh = append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
+	stateid = confirmOpenState(t, conn, xid, fh, 2, stateid)
 	return stateid, fh
 }
 
@@ -3650,14 +3430,14 @@ func collectReaddirNames(t *testing.T, conn net.Conn, xid *uint32, dirFH []byte)
 // [x] TestSetattrSize — truncate staging file via SETATTR
 // [x] TestOpenExclusive4Rejected — EXCLUSIVE4 → NFS4ERR_NOTSUPP
 // [x] TestOpenClaimPrevious — CLAIM_PREVIOUS → NFS4ERR_NO_GRACE
-// [x] TestOpenRflagsNoConfirm — OPEN4_RESULT_CONFIRM absent from rflags
+// [x] TestOpenRflagsRequireConfirm — OPEN4_RESULT_CONFIRM present in rflags
 // [x] TestCloseReplay — CLOSE twice returns OK both times
-// [x] TestCloseExpired — CLOSE on nonexistent inode → NFS4ERR_EXPIRED
+// [x] TestCloseUnknownStateid — unknown stateid returns NFS4ERR_BAD_STATEID
 // [x] TestWriteBadStateid — WRITE with wrong stateid → error
 // [x] TestCommitVerifier — COMMIT returns write verifier
 // [x] TestReadOnlyMode — no staging → NFS4ERR_ROFS
 // [x] TestLockNotSupported — LOCK/LOCKT/LOCKU → NFS4ERR_NOTSUPP
-// [x] TestDeterministicReadStateid — same file+client → same stateid
+// [x] TestOpenStateStoreIssuesUniqueStateids — each OPEN gets unique state
 // [x] TestSetclientidReboot — same identity, different verifier
 
 func TestReaddirPagination(t *testing.T) {
@@ -4220,6 +4000,48 @@ func TestSetattrSize(t *testing.T) {
 	}
 }
 
+func TestSetattrSizeRequiresWriteOpen(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
+	addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientid := setupClient(t, conn, &xid)
+	stateid, fh := openReadFile(t, conn, &xid, clientid, "file.txt")
+
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+
+		saw := w.AppendArgarray_Setattr()
+		sid := saw.Stateid()
+		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
+		for i := 0; i < 12; i++ {
+			sid.SetOther(i, stateid[4+i])
+		}
+		faw := saw.StartObjAttributes()
+		bmW := faw.StartAttrmask()
+		bmW.AppendData(1 << FATTR4_SIZE)
+		buf = bmW.Finish()
+		faw.Resume(buf)
+		attrData := make([]byte, 8)
+		binary.BigEndian.PutUint64(attrData, 1)
+		buf = faw.StartAttrVals().SetData(attrData).Finish()
+		faw.Resume(buf)
+		saw.Resume(faw.Finish())
+		w.Resume(saw.Finish())
+	})
+	if res.Status() != NFS4ERR_OPENMODE {
+		t.Fatalf("SETATTR size status = %s, want NFS4ERR_OPENMODE",
+			Nfsstat4Name(res.Status()))
+	}
+}
+
 func TestOpenExclusive4Rejected(t *testing.T) {
 	dir := t.TempDir()
 	addr, cleanup := startTestServer(t, dir)
@@ -4296,7 +4118,7 @@ func TestOpenClaimPrevious(t *testing.T) {
 	}
 }
 
-func TestOpenRflagsNoConfirm(t *testing.T) {
+func TestOpenRflagsRequireConfirm(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
@@ -4333,8 +4155,8 @@ func TestOpenRflagsNoConfirm(t *testing.T) {
 	entry := nextOp(t, &iter)
 	openOk := entry.Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	rflags := openOk.Rflags()
-	if rflags&OPEN4_RESULT_CONFIRM != 0 {
-		t.Fatal("OPEN4_RESULT_CONFIRM should not be set")
+	if rflags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatal("OPEN4_RESULT_CONFIRM should be set")
 	}
 }
 
@@ -4364,7 +4186,7 @@ func TestCloseReplay(t *testing.T) {
 	}
 }
 
-func TestCloseExpired(t *testing.T) {
+func TestCloseUnknownStateid(t *testing.T) {
 	dir := t.TempDir()
 	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
@@ -4380,8 +4202,8 @@ func TestCloseExpired(t *testing.T) {
 
 	xid := uint32(1)
 	status := closeFileExpectStatus(t, conn, &xid, fakeFH[:], fakeStateid)
-	if status != NFS4ERR_EXPIRED {
-		t.Fatalf("expected NFS4ERR_EXPIRED, got %s", Nfsstat4Name(status))
+	if status != NFS4ERR_BAD_STATEID {
+		t.Fatalf("expected NFS4ERR_BAD_STATEID, got %s", Nfsstat4Name(status))
 	}
 }
 
@@ -4420,12 +4242,97 @@ func TestWriteBadStateid(t *testing.T) {
 	})
 	xid++
 
-	// The WRITE should still succeed because we don't validate stateids
-	// on WRITE (design doc: "Optionally validate the stateid").
-	// Just verify it doesn't crash.
+	if res.Status() != NFS4ERR_BAD_STATEID {
+		t.Fatalf("WRITE with bad stateid: status = %s, want NFS4ERR_BAD_STATEID",
+			Nfsstat4Name(res.Status()))
+	}
+}
+
+// TestWriteSpecialStateid verifies that WRITE accepts the anonymous special
+// stateid (all zeros) on a file already open for write, matching opRead's
+// existing isSpecialStateID exemption. Clients — including pynfs's own
+// nfs4lib.write_file default and the Linux kernel client's zero_stateid
+// fallback — may legitimately omit a real stateid on WRITE.
+func TestWriteSpecialStateid(t *testing.T) {
+	dir := t.TempDir()
+	addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientid := setupClient(t, conn, &xid)
+	_, fh := openCreateFile(t, conn, &xid, clientid, "specialwrite.txt")
+
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		ww := w.AppendArgarray_Write()
+		sid := ww.Stateid()
+		sid.SetSeqid(0)
+		for i := 0; i < 12; i++ {
+			sid.SetOther(i, 0) // anonymous special stateid
+		}
+		ww = ww.SetOffset(0)
+		ww = ww.SetStable(fileSync4)
+		ww = ww.SetData([]byte("hello"))
+		buf = ww.Finish()
+		w.Resume(buf)
+	})
+	xid++
+
+	expectOK(t, res)
+}
+
+// TestSetattrSizeSpecialStateid verifies that SETATTR(SIZE) accepts the
+// anonymous special stateid on a file already open for write, matching
+// opRead's and opWrite's isSpecialStateID exemption. pynfs's own
+// nfs4lib.setattr default stateid is the anonymous one.
+func TestSetattrSizeSpecialStateid(t *testing.T) {
+	dir := t.TempDir()
+	addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientid := setupClient(t, conn, &xid)
+	_, fh := openCreateFile(t, conn, &xid, clientid, "specialsetattr.txt")
+
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		saw := w.AppendArgarray_Setattr()
+		sid := saw.Stateid()
+		sid.SetSeqid(0)
+		for i := 0; i < 12; i++ {
+			sid.SetOther(i, 0) // anonymous special stateid
+		}
+		faw := saw.StartObjAttributes()
+		bmW := faw.StartAttrmask()
+		bmW.AppendData(1 << FATTR4_SIZE)
+		bmW.AppendData(0)
+		buf = bmW.Finish()
+		faw.Resume(buf)
+		attrData := make([]byte, 8)
+		binary.BigEndian.PutUint64(attrData, 10)
+		alW := faw.StartAttrVals()
+		buf = alW.SetData(attrData).Finish()
+		faw.Resume(buf)
+		buf = faw.Finish()
+		saw.Resume(buf)
+		buf = saw.Finish()
+		w.Resume(buf)
+	})
+	xid++
+
 	if res.Status() != NFS4_OK {
-		// If we do validate, the error should be sensible.
-		t.Logf("WRITE with bad stateid: %s (acceptable)", Nfsstat4Name(res.Status()))
+		t.Fatalf("SETATTR(SIZE) with special stateid: status = %s, want NFS4_OK",
+			Nfsstat4Name(res.Status()))
 	}
 }
 
@@ -4604,29 +4511,146 @@ func TestLockNotSupported(t *testing.T) {
 	}
 }
 
-func TestDeterministicReadStateid(t *testing.T) {
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
+func TestOpenStateStoreIssuesUniqueStateids(t *testing.T) {
+	store := newOpenStateStore()
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	first, status := store.addOpen(
+		openOwnerKey{clientID: 1, owner: "first"},
+		1, fileID, false, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatalf("first OPEN status = %s", Nfsstat4Name(status))
+	}
+	second, status := store.addOpen(
+		openOwnerKey{clientID: 1, owner: "second"},
+		1, fileID, false, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
+	}
+	if first.id == second.id {
+		t.Fatalf("OPEN stateids are identical: %x", first.id)
+	}
+}
 
-	addr, cleanup := startTestServer(t, dir)
-	defer cleanup()
-	conn := dial(t, addr)
-	defer conn.Close()
+func TestOpenStateStoreValidation(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 7, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state, status := store.addOpen(
+		owner, 1, fileID, false, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(state.id, 1, fileID, 2); status != NFS4_OK {
+		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
+	}
+	if _, status = store.lookup(state.id, 1, fileID); status != NFS4ERR_OLD_STATEID {
+		t.Fatalf("old stateid status = %s", Nfsstat4Name(status))
+	}
 
-	xid := uint32(1)
-	clientid := setupClient(t, conn, &xid)
+	stale := state.id
+	binary.BigEndian.PutUint32(stale[0:4], 1)
+	if _, status = store.lookup(stale, 2, fileID); status != NFS4ERR_STALE_STATEID {
+		t.Fatalf("stale stateid status = %s", Nfsstat4Name(status))
+	}
+	if _, status = store.lookup(StateID{}, 0, fileID); status != NFS4ERR_BAD_STATEID {
+		t.Fatalf("unknown stateid status = %s", Nfsstat4Name(status))
+	}
 
-	// Open the same file twice and check the stateids are identical.
-	sid1, _ := openReadFile(t, conn, &xid, clientid, "file.txt")
-	sid2, _ := openReadFile(t, conn, &xid, clientid, "file.txt")
+	if _, _, status = store.validateClose(
+		state.id, 2, fileID, 50,
+	); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("bad CLOSE seqid status = %s", Nfsstat4Name(status))
+	}
+	closeState, replay, status := store.validateClose(
+		state.id, 2, fileID, 3,
+	)
+	if status != NFS4_OK || replay {
+		t.Fatalf("CLOSE validation status = %s, replay = %t",
+			Nfsstat4Name(status), replay)
+	}
+	if _, status = store.close(closeState.id, 3); status != NFS4_OK {
+		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
+	}
+	if _, replay, status = store.validateClose(
+		state.id, 2, fileID, 3,
+	); status != NFS4_OK || !replay {
+		t.Fatalf("CLOSE replay status = %s, replay = %t",
+			Nfsstat4Name(status), replay)
+	}
 
-	if sid1 != sid2 {
-		t.Fatalf("read stateids differ: %x vs %x", sid1, sid2)
+	store.purgeClient(owner.clientID)
+	if _, status = store.lookup(state.id, 3, fileID); status != NFS4ERR_EXPIRED {
+		t.Fatalf("expired stateid status = %s", Nfsstat4Name(status))
+	}
+}
+
+func TestOpenStateStoreReplay(t *testing.T) {
+	store := newOpenStateStore()
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	owner := openOwnerKey{clientID: 1, owner: "first"}
+	if _, replay, status := store.beginOpen(owner, 4); status != NFS4_OK || replay {
+		t.Fatalf("initial OPEN status = %s, replay = %t",
+			Nfsstat4Name(status), replay)
+	}
+	state, status := store.addOpen(
+		owner, 4, fileID, true, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	replayed, replay, status := store.beginOpen(owner, 4)
+	if status != NFS4_OK || !replay || replayed.id != state.id {
+		t.Fatalf("OPEN replay status = %s, replay = %t",
+			Nfsstat4Name(status), replay)
+	}
+	if _, status = store.confirm(state.id, 1, fileID, 5); status != NFS4_OK {
+		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
+	}
+	if _, replay, status = store.beginOpen(owner, 4); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("old OPEN seqid status = %s, replay = %t",
+			Nfsstat4Name(status), replay)
+	}
+	second, status := store.addOpen(
+		openOwnerKey{clientID: 1, owner: "second"},
+		1, fileID, false, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
+	}
+	if second.fileID != fileID {
+		t.Fatalf("second OPEN file = %v, want %v", second.fileID, fileID)
+	}
+}
+
+func TestOpenStateStoreRecoveredClose(t *testing.T) {
+	store := newOpenStateStore()
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	var recoveredID StateID
+	binary.BigEndian.PutUint32(recoveredID[0:4], store.epoch+1)
+	recoveredID[11] = 1
+	if !store.canRecover(recoveredID) {
+		t.Fatal("previous-epoch staging stateid was not recoverable")
+	}
+	closed := store.closeRecovered(recoveredID, fileID, 2, 3)
+	if closed.generation != 3 {
+		t.Fatalf("recovered CLOSE generation = %d, want 3",
+			closed.generation)
+	}
+	replayed, replay, status := store.validateClose(
+		recoveredID, 2, fileID, 3,
+	)
+	if status != NFS4_OK || !replay || replayed.id != recoveredID {
+		t.Fatalf("recovered CLOSE replay status = %s, replay = %t",
+			Nfsstat4Name(status), replay)
 	}
 }
 
 func TestSetclientidReboot(t *testing.T) {
 	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
 	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
@@ -4635,6 +4659,7 @@ func TestSetclientidReboot(t *testing.T) {
 	// First SETCLIENTID + CONFIRM.
 	xid := uint32(1)
 	clientid1 := setupClient(t, conn, &xid)
+	stateid, fh := openReadFile(t, conn, &xid, clientid1, "file.txt")
 
 	// Second SETCLIENTID with same identity but different verifier (simulating reboot).
 	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
@@ -4687,9 +4712,10 @@ func TestSetclientidReboot(t *testing.T) {
 		t.Fatal("SETCLIENTID_CONFIRM reboot failed")
 	}
 
-	// The new client ID should differ (new file = new InodeID).
-	if clientid1 == clientid2 {
-		t.Log("client IDs are the same (verifier stored in same file)")
+	status := closeFileExpectStatus(t, conn, &xid, fh, stateid)
+	if status != NFS4ERR_EXPIRED {
+		t.Fatalf("CLOSE after client reboot = %s, want NFS4ERR_EXPIRED",
+			Nfsstat4Name(status))
 	}
 }
 

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -7,11 +7,14 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 )
@@ -28,7 +31,11 @@ func startTestServer(t *testing.T, dir string) (addr string, cleanup func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return serveTestServer(t, srv)
+}
 
+func serveTestServer(t *testing.T, srv *Server) (addr string, cleanup func()) {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -3215,6 +3222,74 @@ func confirmOpenState(
 	return confirmed
 }
 
+func openFileForOwner(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	clientID uint64,
+	owner string,
+	seq uint32,
+	filename string,
+	access uint32,
+	create bool,
+	guarded bool,
+) (status uint32, stateid [16]byte, fh []byte, rflags uint32) {
+	t.Helper()
+	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
+		w.AppendArgarray_Putrootfh()
+		ow := w.AppendArgarray_Open()
+		ow.SetSeqid(seq)
+		ow.SetShareAccess(access)
+		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
+		ownerW := ow.StartOwner()
+		ownerW = ownerW.SetClientid(clientID)
+		ownerW = ownerW.SetOwner([]byte(owner))
+		buf := ownerW.Finish()
+		ow.Resume(buf)
+		if create {
+			chw := ow.SetOpenhow_Create()
+			var faw Fattr4Writer
+			if guarded {
+				faw = chw.SetValue_Guarded4()
+			} else {
+				faw = chw.SetValue_Unchecked4()
+			}
+			bmW := faw.StartAttrmask()
+			buf = bmW.Finish()
+			faw.Resume(buf)
+			alW := faw.StartAttrVals()
+			buf = alW.SetData(nil).Finish()
+			faw.Resume(buf)
+			chw.Resume(faw.Finish())
+			ow.Resume(chw.Finish())
+		} else {
+			ow.SetOpenhow_Default(OPEN4_NOCREATE)
+		}
+		cw := ow.SetClaim_Null()
+		buf = cw.SetData([]byte(filename)).Finish()
+		ow.Resume(buf)
+		w.Resume(ow.Finish())
+		w.AppendArgarray_Getfh()
+	})
+	*xid++
+	if res.Status() != NFS4_OK {
+		return res.Status(), stateid, nil, 0
+	}
+	iter := expectOK(t, res)
+	nextOp(t, &iter)
+	openEntry := nextOp(t, &iter)
+	openOK := openEntry.Value().AsOPEN4resEntry().Value().AsOPEN4resok()
+	sid := openOK.Stateid()
+	binary.BigEndian.PutUint32(stateid[:4], sid.Seqid())
+	for i := 0; i < 12; i++ {
+		stateid[4+i] = sid.Other(i)
+	}
+	fhEntry := nextOp(t, &iter)
+	fh = append([]byte(nil), fhEntry.Value().AsGETFH4resEntry().
+		Value().AsGETFH4resok().Object().Data()...)
+	return NFS4_OK, stateid, fh, openOK.Rflags()
+}
+
 // openReadFile opens a file for read and returns the open stateid and filehandle.
 func openReadFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, filename string) (stateid [16]byte, fh []byte) {
 	t.Helper()
@@ -3313,27 +3388,20 @@ func openCreateFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, f
 // closeFile sends CLOSE for the given filehandle and stateid.
 func closeFile(t *testing.T, conn net.Conn, xid *uint32, fh []byte, stateid [16]byte) {
 	t.Helper()
-	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
-		pw := w.AppendArgarray_Putfh()
-		fhW := pw.StartObject()
-		buf := fhW.SetData(fh).Finish()
-		pw.Resume(buf)
-		buf = pw.Finish()
-		w.Resume(buf)
-		caw := w.AppendArgarray_Close()
-		caw.SetSeqid(3)
-		sid := caw.OpenStateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
-	})
-	*xid++
-	expectOK(t, res)
+	status := closeFileWithSeqStatus(t, conn, xid, fh, stateid, 3)
+	if status != NFS4_OK {
+		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
+	}
 }
 
-// closeFileExpectStatus sends CLOSE and returns the NFS status.
-func closeFileExpectStatus(t *testing.T, conn net.Conn, xid *uint32, fh []byte, stateid [16]byte) uint32 {
+func closeFileWithSeqStatus(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	fh []byte,
+	stateid [16]byte,
+	seq uint32,
+) uint32 {
 	t.Helper()
 	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
@@ -3343,7 +3411,7 @@ func closeFileExpectStatus(t *testing.T, conn net.Conn, xid *uint32, fh []byte, 
 		buf = pw.Finish()
 		w.Resume(buf)
 		caw := w.AppendArgarray_Close()
-		caw.SetSeqid(3)
+		caw.SetSeqid(seq)
 		sid := caw.OpenStateid()
 		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
 		for i := 0; i < 12; i++ {
@@ -3351,8 +3419,13 @@ func closeFileExpectStatus(t *testing.T, conn net.Conn, xid *uint32, fh []byte, 
 		}
 	})
 	*xid++
-	// The compound status reflects the CLOSE status.
 	return res.Status()
+}
+
+// closeFileExpectStatus sends CLOSE and returns the NFS status.
+func closeFileExpectStatus(t *testing.T, conn net.Conn, xid *uint32, fh []byte, stateid [16]byte) uint32 {
+	t.Helper()
+	return closeFileWithSeqStatus(t, conn, xid, fh, stateid, 3)
 }
 
 // collectReaddirNames issues READDIR calls to collect all names in a directory.
@@ -4160,6 +4233,39 @@ func TestOpenRflagsRequireConfirm(t *testing.T) {
 	}
 }
 
+func TestOpenConfirmReplay(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "file.txt"), []byte("data"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, stateid, fh, _ := openFileForOwner(
+		t, conn, &xid, clientID, "owner", 1, "file.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	first := confirmOpenState(t, conn, &xid, fh, 2, stateid)
+	replayed := confirmOpenState(t, conn, &xid, fh, 2, stateid)
+	if replayed != first {
+		t.Fatalf("OPEN_CONFIRM replay stateid = %x, want %x",
+			replayed, first)
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, first, 3,
+	); status != NFS4_OK {
+		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
+	}
+}
+
 func TestCloseReplay(t *testing.T) {
 	dir := t.TempDir()
 	addr, cleanup := startTestServer(t, dir)
@@ -4183,6 +4289,385 @@ func TestCloseReplay(t *testing.T) {
 	status := closeFileExpectStatus(t, conn, &xid, fh, stateid)
 	if status != NFS4_OK {
 		t.Fatalf("CLOSE replay: expected NFS4_OK, got %s", Nfsstat4Name(status))
+	}
+}
+
+func TestFailedOpenAdvancesOwnerSeqid(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "existing.txt"), []byte("existing"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, stateid, fh, rflags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 1, "new.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("initial OPEN status = %s", Nfsstat4Name(status))
+	}
+	if rflags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatal("first OPEN did not require confirmation")
+	}
+	stateid = confirmOpenState(t, conn, &xid, fh, 2, stateid)
+
+	status, _, _, _ = openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 3, "existing.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, true,
+	)
+	if status != NFS4ERR_EXIST {
+		t.Fatalf("guarded OPEN status = %s, want NFS4ERR_EXIST",
+			Nfsstat4Name(status))
+	}
+	status, _, _, _ = openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 3, "existing.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, true,
+	)
+	if status != NFS4ERR_EXIST {
+		t.Fatalf("guarded OPEN replay = %s, want NFS4ERR_EXIST",
+			Nfsstat4Name(status))
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 4,
+	); status != NFS4_OK {
+		t.Fatalf("CLOSE after failed OPEN = %s, want NFS4_OK",
+			Nfsstat4Name(status))
+	}
+}
+
+func TestOnlyFirstOpenRequiresConfirmation(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"first.txt", "second.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	addr, cleanup := startTestServer(t, dir)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, firstState, firstFH, firstFlags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 1, "first.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK || firstFlags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatalf("first OPEN status = %s, rflags = %#x",
+			Nfsstat4Name(status), firstFlags)
+	}
+	firstState = confirmOpenState(
+		t, conn, &xid, firstFH, 2, firstState)
+
+	status, secondState, secondFH, secondFlags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 3, "second.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
+	}
+	if secondFlags&OPEN4_RESULT_CONFIRM != 0 {
+		t.Fatal("second OPEN unnecessarily required confirmation")
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, secondFH, secondState, 4,
+	); status != NFS4_OK {
+		t.Fatalf("second CLOSE status = %s", Nfsstat4Name(status))
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, firstFH, firstState, 5,
+	); status != NFS4_OK {
+		t.Fatalf("first CLOSE status = %s", Nfsstat4Name(status))
+	}
+}
+
+type blockingConstructVFS struct {
+	TernVFS
+
+	mu            sync.Mutex
+	calls         int
+	firstEntered  chan struct{}
+	secondEntered chan struct{}
+	releaseFirst  chan struct{}
+}
+
+func (fs *blockingConstructVFS) ConstructFile(
+	dirID InodeID,
+) (InodeID, Cookie, error) {
+	fs.mu.Lock()
+	fs.calls++
+	call := fs.calls
+	fs.mu.Unlock()
+	switch call {
+	case 1:
+		close(fs.firstEntered)
+		<-fs.releaseFirst
+	case 2:
+		close(fs.secondEntered)
+	}
+	return fs.TernVFS.ConstructFile(dirID)
+}
+
+func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
+	fs := &blockingConstructVFS{
+		TernVFS:       NewLocalTernVFS(t.TempDir()),
+		firstEntered:  make(chan struct{}),
+		secondEntered: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(fs, staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	firstConn := dial(t, addr)
+	defer firstConn.Close()
+	secondConn := dial(t, addr)
+	defer secondConn.Close()
+	xid := uint32(1)
+	clientID := setupClient(t, firstConn, &xid)
+
+	type result struct {
+		status  uint32
+		stateid [16]byte
+		fh      []byte
+	}
+	results := make(chan result, 2)
+	open := func(conn net.Conn, xid uint32) {
+		status, stateid, fh, _ := openFileForOwner(
+			t, conn, &xid, clientID, "shared-owner", 1, "race.txt",
+			OPEN4_SHARE_ACCESS_BOTH, true, false,
+		)
+		results <- result{status: status, stateid: stateid, fh: fh}
+	}
+	go open(firstConn, 100)
+	<-fs.firstEntered
+	go open(secondConn, 200)
+
+	concurrent := false
+	select {
+	case <-fs.secondEntered:
+		concurrent = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(fs.releaseFirst)
+	first := <-results
+	second := <-results
+
+	if concurrent {
+		t.Fatal("retransmitted OPEN entered ConstructFile concurrently")
+	}
+	if first.status != NFS4_OK || second.status != NFS4_OK {
+		t.Fatalf("concurrent OPEN statuses = %s, %s",
+			Nfsstat4Name(first.status), Nfsstat4Name(second.status))
+	}
+	if first.stateid != second.stateid || !bytes.Equal(first.fh, second.fh) {
+		t.Fatal("OPEN replay returned different state")
+	}
+	fs.mu.Lock()
+	calls := fs.calls
+	fs.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("ConstructFile calls = %d, want 1", calls)
+	}
+}
+
+type failingLinkVFS struct {
+	TernVFS
+
+	mu        sync.Mutex
+	remaining int
+}
+
+func (fs *failingLinkVFS) LinkFile(
+	fileID InodeID,
+	cookie Cookie,
+	dirID InodeID,
+	name string,
+	data io.Reader,
+) error {
+	fs.mu.Lock()
+	if fs.remaining > 0 {
+		fs.remaining--
+		fs.mu.Unlock()
+		return errors.New("injected LinkFile failure")
+	}
+	fs.mu.Unlock()
+	return fs.TernVFS.LinkFile(fileID, cookie, dirID, name, data)
+}
+
+func TestFailedCloseAdvancesAndReplaysOwnerSeqid(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "read.txt"), []byte("read"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	fs := &failingLinkVFS{
+		TernVFS:   NewLocalTernVFS(dir),
+		remaining: 1,
+	}
+	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(fs, staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, stateid, fh, _ := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 1, "write.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	stateid = confirmOpenState(t, conn, &xid, fh, 2, stateid)
+
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 3,
+	); status != NFS4ERR_IO {
+		t.Fatalf("failed CLOSE status = %s, want NFS4ERR_IO",
+			Nfsstat4Name(status))
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 3,
+	); status != NFS4ERR_IO {
+		t.Fatalf("failed CLOSE replay = %s, want NFS4ERR_IO",
+			Nfsstat4Name(status))
+	}
+	status, _, _, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 4, "read.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN after failed CLOSE = %s, want NFS4_OK",
+			Nfsstat4Name(status))
+	}
+	if flags&OPEN4_RESULT_CONFIRM != 0 {
+		t.Fatal("established owner required confirmation after failed CLOSE")
+	}
+}
+
+type blockingLinkVFS struct {
+	TernVFS
+
+	mu            sync.Mutex
+	calls         int
+	firstEntered  chan struct{}
+	secondEntered chan struct{}
+	releaseFirst  chan struct{}
+}
+
+func (fs *blockingLinkVFS) LinkFile(
+	fileID InodeID,
+	cookie Cookie,
+	dirID InodeID,
+	name string,
+	data io.Reader,
+) error {
+	fs.mu.Lock()
+	fs.calls++
+	call := fs.calls
+	fs.mu.Unlock()
+	switch call {
+	case 1:
+		close(fs.firstEntered)
+		<-fs.releaseFirst
+	case 2:
+		close(fs.secondEntered)
+	}
+	return fs.TernVFS.LinkFile(fileID, cookie, dirID, name, data)
+}
+
+func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
+	fs := &blockingLinkVFS{
+		TernVFS:       NewLocalTernVFS(t.TempDir()),
+		firstEntered:  make(chan struct{}),
+		secondEntered: make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+	}
+	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(fs, staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	firstConn := dial(t, addr)
+	defer firstConn.Close()
+	secondConn := dial(t, addr)
+	defer secondConn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, firstConn, &xid)
+	status, stateid, fh, _ := openFileForOwner(
+		t, firstConn, &xid, clientID, "shared-owner", 1, "race.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	stateid = confirmOpenState(t, firstConn, &xid, fh, 2, stateid)
+
+	statuses := make(chan uint32, 2)
+	go func() {
+		closeXID := uint32(100)
+		statuses <- closeFileWithSeqStatus(
+			t, firstConn, &closeXID, fh, stateid, 3)
+	}()
+	<-fs.firstEntered
+	go func() {
+		closeXID := uint32(200)
+		statuses <- closeFileWithSeqStatus(
+			t, secondConn, &closeXID, fh, stateid, 3)
+	}()
+
+	concurrent := false
+	select {
+	case <-fs.secondEntered:
+		concurrent = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(fs.releaseFirst)
+	firstStatus := <-statuses
+	secondStatus := <-statuses
+
+	if concurrent {
+		t.Fatal("retransmitted CLOSE entered LinkFile concurrently")
+	}
+	if firstStatus != NFS4_OK || secondStatus != NFS4_OK {
+		t.Fatalf("concurrent CLOSE statuses = %s, %s",
+			Nfsstat4Name(firstStatus), Nfsstat4Name(secondStatus))
+	}
+	fs.mu.Lock()
+	calls := fs.calls
+	fs.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("LinkFile calls = %d, want 1", calls)
 	}
 }
 
@@ -4546,6 +5031,12 @@ func TestOpenStateStoreValidation(t *testing.T) {
 	if _, status = store.confirm(state.id, 1, fileID, 2); status != NFS4_OK {
 		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
 	}
+	if _, _, status = store.validateClose(
+		state.id, 1, fileID, 50,
+	); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("CLOSE error priority status = %s, want NFS4ERR_BAD_SEQID",
+			Nfsstat4Name(status))
+	}
 	if _, status = store.lookup(state.id, 1, fileID); status != NFS4ERR_OLD_STATEID {
 		t.Fatalf("old stateid status = %s", Nfsstat4Name(status))
 	}
@@ -4609,6 +5100,11 @@ func TestOpenStateStoreReplay(t *testing.T) {
 	if _, status = store.confirm(state.id, 1, fileID, 5); status != NFS4_OK {
 		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
 	}
+	confirmed, status := store.confirm(state.id, 1, fileID, 5)
+	if status != NFS4_OK || confirmed.generation != 2 {
+		t.Fatalf("OPEN_CONFIRM replay status = %s, generation = %d",
+			Nfsstat4Name(status), confirmed.generation)
+	}
 	if _, replay, status = store.beginOpen(owner, 4); status != NFS4ERR_BAD_SEQID {
 		t.Fatalf("old OPEN seqid status = %s, replay = %t",
 			Nfsstat4Name(status), replay)
@@ -4622,6 +5118,150 @@ func TestOpenStateStoreReplay(t *testing.T) {
 	}
 	if second.fileID != fileID {
 		t.Fatalf("second OPEN file = %v, want %v", second.fileID, fileID)
+	}
+}
+
+func TestOpenStateStoreExemptErrorDoesNotAdvance(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 1, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state, status := store.addOpen(
+		owner, 1, fileID, false, StateID{})
+	if status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		state.id, 2, fileID, 50,
+	); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("OPEN_CONFIRM error priority = %s, want NFS4ERR_BAD_SEQID",
+			Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		state.id, 2, fileID, 2,
+	); status != NFS4ERR_BAD_STATEID {
+		t.Fatalf("bad OPEN_CONFIRM stateid = %s", Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		state.id, 1, fileID, 2,
+	); status != NFS4_OK {
+		t.Fatalf("OPEN_CONFIRM after exempt error = %s",
+			Nfsstat4Name(status))
+	}
+}
+
+func TestOpenStateStoreDisposesClosedStateAndBoundsOwnerReplay(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 1, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state, status := store.addOpen(
+		owner, 1, fileID, false, StateID{})
+	if status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		state.id, 1, fileID, 2,
+	); status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if _, status = store.close(state.id, 3); status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if len(store.states) != 0 {
+		t.Fatalf("closed states retained = %d", len(store.states))
+	}
+	if len(store.owners) != 1 || len(store.replayOwners) != 1 {
+		t.Fatalf("replay cache owners=%d stateids=%d, want 1, 1",
+			len(store.owners), len(store.replayOwners))
+	}
+
+	secondFileID := MakeInodeID(InodeTypeFile, 2)
+	if _, status = store.addOpen(
+		owner, 4, secondFileID, false, StateID{},
+	); status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if len(store.states) != 1 || len(store.owners) != 1 ||
+		len(store.replayOwners) != 0 {
+		t.Fatalf("replacement response retained old state: states=%d owners=%d replays=%d",
+			len(store.states), len(store.owners), len(store.replayOwners))
+	}
+}
+
+func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
+	store := newOpenStateStore()
+	clientID := uint64(1)
+	var states []openState
+	for i, name := range []string{"user-a", "user-b"} {
+		fileID := MakeInodeID(InodeTypeFile, uint64(i+1))
+		state, status := store.addOpen(
+			openOwnerKey{clientID: clientID, owner: name},
+			1, fileID, false, StateID{})
+		if status != NFS4_OK {
+			t.Fatal(Nfsstat4Name(status))
+		}
+		if _, status = store.confirm(
+			state.id, 1, fileID, 2,
+		); status != NFS4_OK {
+			t.Fatal(Nfsstat4Name(status))
+		}
+		states = append(states, state)
+	}
+
+	for range 10 {
+		if _, status := store.lookup(
+			states[0].id, 2, states[0].fileID,
+		); status != NFS4_OK {
+			t.Fatal(Nfsstat4Name(status))
+		}
+	}
+	if _, status := store.lookup(
+		states[1].id, 2, states[1].fileID,
+	); status != NFS4_OK {
+		t.Fatalf("activity by one owner invalidated another: %s",
+			Nfsstat4Name(status))
+	}
+
+	store.purgeClient(clientID)
+	for _, state := range states {
+		if _, status := store.lookup(
+			state.id, 2, state.fileID,
+		); status != NFS4ERR_EXPIRED {
+			t.Fatalf("reboot-purged state = %s", Nfsstat4Name(status))
+		}
+	}
+}
+
+func TestOpenStateStoreBoundsRebootTombstones(t *testing.T) {
+	store := newOpenStateStore()
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	var firstStateID StateID
+	for i := 0; i <= maxRecoveredCloseResponses; i++ {
+		clientID := uint64(i + 1)
+		state, status := store.addOpen(
+			openOwnerKey{clientID: clientID, owner: "owner"},
+			1, fileID, false, StateID{})
+		if status != NFS4_OK {
+			t.Fatal(Nfsstat4Name(status))
+		}
+		if i == 0 {
+			firstStateID = state.id
+		}
+		store.purgeClient(clientID)
+	}
+
+	if len(store.expired) != maxRecoveredCloseResponses {
+		t.Fatalf("expired stateids = %d, want %d",
+			len(store.expired), maxRecoveredCloseResponses)
+	}
+	if len(store.revoked) != maxRecoveredCloseResponses {
+		t.Fatalf("revoked clientids = %d, want %d",
+			len(store.revoked), maxRecoveredCloseResponses)
+	}
+	if _, found := store.expired[firstStateID]; found {
+		t.Fatal("oldest expired stateid was not evicted")
+	}
+	if _, found := store.revoked[1]; found {
+		t.Fatal("oldest revoked clientid was not evicted")
 	}
 }
 
@@ -4645,6 +5285,187 @@ func TestOpenStateStoreRecoveredClose(t *testing.T) {
 	if status != NFS4_OK || !replay || replayed.id != recoveredID {
 		t.Fatalf("recovered CLOSE replay status = %s, replay = %t",
 			Nfsstat4Name(status), replay)
+	}
+}
+
+func closeLocalStagingFiles(t *testing.T, store *LocalStagingStore) {
+	t.Helper()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, entry := range store.files {
+		if err := entry.file.f.Sync(); err != nil {
+			t.Fatal(err)
+		}
+		if err := entry.file.f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
+	rootDir := t.TempDir()
+	stagingDir := t.TempDir()
+	fs := NewLocalTernVFS(rootDir)
+	firstStaging, err := NewLocalStagingStore(stagingDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := NewServer(fs, firstStaging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, stopFirst := serveTestServer(t, first)
+	conn := dial(t, addr)
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	stateid, fh := openCreateFile(
+		t, conn, &xid, clientID, "recovered.txt")
+	data := []byte("staged across an nfsd restart")
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		pw := w.AppendArgarray_Putfh()
+		buf := pw.StartObject().SetData(fh).Finish()
+		pw.Resume(buf)
+		w.Resume(pw.Finish())
+		ww := w.AppendArgarray_Write()
+		sid := ww.Stateid()
+		sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
+		for i := 0; i < 12; i++ {
+			sid.SetOther(i, stateid[4+i])
+		}
+		ww = ww.SetOffset(0)
+		ww = ww.SetStable(fileSync4)
+		ww = ww.SetData(data)
+		w.Resume(ww.Finish())
+	})
+	expectOK(t, res)
+	fileID, ok := fhToInodeID(fh)
+	if !ok {
+		t.Fatal("invalid filehandle returned by OPEN")
+	}
+	conn.Close()
+	stopFirst()
+	closeLocalStagingFiles(t, firstStaging)
+
+	recoveredStaging, err := NewLocalStagingStore(stagingDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found := recoveredStaging.GetMeta(fileID); !found {
+		t.Fatal("staging sidecar was not recovered")
+	}
+	second, err := NewServer(fs, recoveredStaging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, stopSecond := serveTestServer(t, second)
+	defer stopSecond()
+	conn = dial(t, addr)
+	defer conn.Close()
+
+	closeXID := uint32(100)
+	if status := closeFileWithSeqStatus(
+		t, conn, &closeXID, fh, stateid, 3,
+	); status != NFS4_OK {
+		t.Fatalf("recovered CLOSE = %s", Nfsstat4Name(status))
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &closeXID, fh, stateid, 3,
+	); status != NFS4_OK {
+		t.Fatalf("recovered CLOSE replay = %s", Nfsstat4Name(status))
+	}
+	got, err := os.ReadFile(filepath.Join(rootDir, "recovered.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("recovered file data = %q, want %q", got, data)
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("recovered CLOSE retained staging files: %v", entries)
+	}
+}
+
+func TestSetclientidRebootRemovesStagingFiles(t *testing.T) {
+	rootDir := t.TempDir()
+	stagingDir := t.TempDir()
+	fs := NewLocalTernVFS(rootDir)
+	staging, err := NewLocalStagingStore(stagingDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(fs, staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	stateid, fh := openCreateFile(
+		t, conn, &xid, clientID, "reboot.txt")
+	fileID, ok := fhToInodeID(fh)
+	if !ok {
+		t.Fatal("invalid filehandle returned by OPEN")
+	}
+	if staging.Get(fileID) == nil {
+		t.Fatal("write OPEN did not create staging")
+	}
+
+	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		scw := w.AppendArgarray_Setclientid()
+		clientW := scw.StartClient()
+		for i := 0; i < 8; i++ {
+			clientW.Verifier().SetData(i, byte(i+1))
+		}
+		clientW = clientW.SetId([]byte("test-client"))
+		buf := clientW.Finish()
+		scw.Resume(buf)
+		cbW := scw.StartCallback()
+		cbW.SetCbProgram(0x40000000)
+		locW := cbW.StartCbLocation()
+		buf = locW.StartRNetid().SetData([]byte("tcp")).Finish()
+		locW.Resume(buf)
+		buf = locW.StartRAddr().SetData([]byte("0.0.0.0.0.0")).Finish()
+		locW.Resume(buf)
+		cbW.Resume(locW.Finish())
+		scw.Resume(cbW.Finish())
+		scw.SetCallbackIdent(0)
+		w.Resume(scw.Finish())
+	})
+	xid++
+	iter := expectOK(t, res)
+	entry := nextOp(t, &iter)
+	newClientID := entry.Value().AsSETCLIENTID4resEntry().
+		Value().AsSETCLIENTID4resok().Clientid()
+	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+		cw := w.AppendArgarray_SetclientidConfirm()
+		cw.SetClientid(newClientID)
+	})
+	xid++
+	expectOK(t, res)
+
+	if staging.Get(fileID) != nil {
+		t.Fatal("client reboot retained staging in memory")
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("client reboot retained staging files: %v", entries)
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 3,
+	); status != NFS4ERR_EXPIRED {
+		t.Fatalf("CLOSE after reboot = %s, want NFS4ERR_EXPIRED",
+			Nfsstat4Name(status))
 	}
 }
 

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -219,6 +219,41 @@ func nextOp(t *testing.T, iter *NfsResop4EntryIter) NfsResop4Entry {
 	return iter.Resarray()
 }
 
+const testChannelTimeout = 5 * time.Second
+
+func awaitSignal(t *testing.T, ch <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(testChannelTimeout):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func awaitValue[T any](
+	t *testing.T,
+	ch <-chan T,
+	description string,
+) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(testChannelTimeout):
+		t.Fatalf("timed out waiting for %s", description)
+		var zero T
+		return zero
+	}
+}
+
+func closeSignal(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
+}
+
 // getAttrData extracts attribute values from a GETATTR4resok fattr4.
 // Uses Fattr4.AttrVals().Data() which requires correct codegen for
 // sequential variable-size field getters (bitmap4 then attrlist4).
@@ -3425,10 +3460,27 @@ func openCreateFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, f
 // closeFile sends CLOSE for the given filehandle and stateid.
 func closeFile(t *testing.T, conn net.Conn, xid *uint32, fh []byte, stateid [16]byte) {
 	t.Helper()
-	status := closeFileWithSeqStatus(t, conn, xid, fh, stateid, 3)
+	status, _ := closeFileWithSeqResult(t, conn, xid, fh, stateid, 3)
 	if status != NFS4_OK {
 		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
 	}
+}
+
+func closeFileWithSeqResult(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	fh []byte,
+	stateid [16]byte,
+	seq uint32,
+) (uint32, [16]byte) {
+	t.Helper()
+	status, result, err := closeFileWithSeqResultE(
+		conn, xid, fh, stateid, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return status, result
 }
 
 func closeFileWithSeqStatus(
@@ -3440,20 +3492,18 @@ func closeFileWithSeqStatus(
 	seq uint32,
 ) uint32 {
 	t.Helper()
-	status, err := closeFileWithSeqStatusE(conn, xid, fh, stateid, seq)
-	if err != nil {
-		t.Fatal(err)
-	}
+	status, _ := closeFileWithSeqResult(t, conn, xid, fh, stateid, seq)
 	return status
 }
 
-func closeFileWithSeqStatusE(
+func closeFileWithSeqResultE(
 	conn net.Conn,
 	xid *uint32,
 	fh []byte,
 	stateid [16]byte,
 	seq uint32,
-) (uint32, error) {
+) (uint32, [16]byte, error) {
+	var result [16]byte
 	body := buildCompoundBody(nil, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
 		fhW := pw.StartObject()
@@ -3468,17 +3518,30 @@ func closeFileWithSeqStatusE(
 	reply, err := sendRPC(conn, *xid, procCompound, body)
 	*xid++
 	if err != nil {
-		return 0, err
+		return 0, result, err
 	}
 	nfsBody, err := parseRPCReply(reply)
 	if err != nil {
-		return 0, err
+		return 0, result, err
 	}
 	res, ok := ReadCOMPOUND4res(nfsBody)
 	if !ok {
-		return 0, errors.New("failed to parse COMPOUND4res")
+		return 0, result, errors.New("failed to parse COMPOUND4res")
 	}
-	return res.Status(), nil
+	if res.Status() == NFS4_OK {
+		iter := res.Resarray()
+		if !iter.Next() || !iter.Next() {
+			return 0, result, errors.New(
+				"CLOSE response is missing PUTFH or CLOSE")
+		}
+		sid := iter.Resarray().Value().AsCLOSE4resEntry().
+			Value().AsStateid4()
+		binary.BigEndian.PutUint32(result[:4], sid.Seqid())
+		for i := range 12 {
+			result[4+i] = sid.Other(i)
+		}
+	}
+	return res.Status(), result, nil
 }
 
 // collectReaddirNames issues READDIR calls to collect all names in a directory.
@@ -4361,7 +4424,11 @@ func TestCloseReplay(t *testing.T) {
 
 	// Create and close a file.
 	stateid, fh := openCreateFile(t, conn, &xid, clientid, "replay.txt")
-	closeFile(t, conn, &xid, fh, stateid)
+	status, first := closeFileWithSeqResult(
+		t, conn, &xid, fh, stateid, 3)
+	if status != NFS4_OK {
+		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
+	}
 
 	// Verify file exists.
 	if _, err := os.Stat(filepath.Join(dir, "replay.txt")); err != nil {
@@ -4369,9 +4436,13 @@ func TestCloseReplay(t *testing.T) {
 	}
 
 	// Send CLOSE again (replay). Should succeed.
-	status := closeFileWithSeqStatus(t, conn, &xid, fh, stateid, 3)
+	status, replay := closeFileWithSeqResult(
+		t, conn, &xid, fh, stateid, 3)
 	if status != NFS4_OK {
 		t.Fatalf("CLOSE replay: expected NFS4_OK, got %s", Nfsstat4Name(status))
+	}
+	if replay != first {
+		t.Fatalf("CLOSE replay stateid = %x, want %x", replay, first)
 	}
 }
 
@@ -4761,15 +4832,20 @@ type blockingVFSGate struct {
 	releaseFirst chan struct{}
 }
 
-func (gate *blockingVFSGate) enter() {
+func (gate *blockingVFSGate) enter() error {
 	gate.mu.Lock()
 	gate.calls++
 	call := gate.calls
 	gate.mu.Unlock()
 	if call == 1 {
 		close(gate.firstEntered)
-		<-gate.releaseFirst
+		select {
+		case <-gate.releaseFirst:
+		case <-time.After(testChannelTimeout):
+			return errors.New("timed out waiting to release VFS gate")
+		}
 	}
+	return nil
 }
 
 func (gate *blockingVFSGate) callCount() int {
@@ -4786,11 +4862,13 @@ type blockingConstructVFS struct {
 func (fs *blockingConstructVFS) ConstructFile(
 	dirID InodeID,
 ) (InodeID, Cookie, error) {
-	fs.enter()
+	if err := fs.enter(); err != nil {
+		return 0, Cookie{}, err
+	}
 	return fs.TernVFS.ConstructFile(dirID)
 }
 
-func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
+func TestConcurrentOpenIsAtMostOnceAndReplayed(t *testing.T) {
 	fs := &blockingConstructVFS{
 		TernVFS: NewLocalTernVFS(t.TempDir()),
 		blockingVFSGate: blockingVFSGate{
@@ -4798,6 +4876,7 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 			releaseFirst: make(chan struct{}),
 		},
 	}
+	defer closeSignal(fs.releaseFirst)
 	staging, err := NewLocalStagingStore(t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -4814,17 +4893,6 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 	defer secondConn.Close()
 	xid := uint32(1)
 	clientID := setupClient(t, firstConn, &xid)
-	secondRequestEntered := make(chan struct{})
-	var startMu sync.Mutex
-	startCalls := 0
-	srv.beforeStartOpen = func() {
-		startMu.Lock()
-		defer startMu.Unlock()
-		startCalls++
-		if startCalls == 2 {
-			close(secondRequestEntered)
-		}
-	}
 
 	type result struct {
 		status  uint32
@@ -4843,12 +4911,11 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 		}
 	}
 	go open(firstConn, 100)
-	<-fs.firstEntered
+	awaitSignal(t, fs.firstEntered, "first OPEN entering ConstructFile")
 	go open(secondConn, 200)
-	<-secondRequestEntered
-	close(fs.releaseFirst)
-	first := <-results
-	second := <-results
+	closeSignal(fs.releaseFirst)
+	first := awaitValue(t, results, "first concurrent OPEN result")
+	second := awaitValue(t, results, "second concurrent OPEN result")
 
 	if first.err != nil || second.err != nil {
 		t.Fatalf("concurrent OPEN errors = %v, %v", first.err, second.err)
@@ -4873,8 +4940,9 @@ type failingLinkVFS struct {
 }
 
 type closeResult struct {
-	status uint32
-	err    error
+	status  uint32
+	stateid [16]byte
+	err     error
 }
 
 func (fs *failingLinkVFS) LinkFile(
@@ -4909,7 +4977,11 @@ func (fs *blockingFailingLinkVFS) LinkFile(
 	io.Reader,
 ) error {
 	fs.once.Do(func() { close(fs.entered) })
-	<-fs.release
+	select {
+	case <-fs.release:
+	case <-time.After(testChannelTimeout):
+		return errors.New("timed out waiting to release LinkFile")
+	}
 	return errors.New("injected LinkFile failure")
 }
 
@@ -4949,6 +5021,7 @@ func TestWaitingCloseRechecksStagingMeta(t *testing.T) {
 		entered: make(chan struct{}),
 		release: make(chan struct{}),
 	}
+	defer closeSignal(fs.release)
 	localStaging, err := NewLocalStagingStore(t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -4979,24 +5052,28 @@ func TestWaitingCloseRechecksStagingMeta(t *testing.T) {
 	firstResult := make(chan closeResult, 1)
 	go func() {
 		closeXID := uint32(100)
-		status, err := closeFileWithSeqStatusE(
+		status, result, err := closeFileWithSeqResultE(
 			firstConn, &closeXID, fh, stateid, 3)
-		firstResult <- closeResult{status: status, err: err}
+		firstResult <- closeResult{
+			status: status, stateid: result, err: err,
+		}
 	}()
-	<-fs.entered
+	awaitSignal(t, fs.entered, "first CLOSE entering LinkFile")
 	secondRead := staging.notifyNextGetMeta()
 	secondResult := make(chan closeResult, 1)
 	go func() {
 		closeXID := uint32(200)
-		status, err := closeFileWithSeqStatusE(
+		status, result, err := closeFileWithSeqResultE(
 			secondConn, &closeXID, fh, stateid, 4)
-		secondResult <- closeResult{status: status, err: err}
+		secondResult <- closeResult{
+			status: status, stateid: result, err: err,
+		}
 	}()
-	<-secondRead
-	close(fs.release)
+	awaitSignal(t, secondRead, "second CLOSE reading staging metadata")
+	closeSignal(fs.release)
 
-	first := <-firstResult
-	second := <-secondResult
+	first := awaitValue(t, firstResult, "first racing CLOSE result")
+	second := awaitValue(t, secondResult, "second racing CLOSE result")
 	if first.err != nil || second.err != nil {
 		t.Fatalf("CLOSE errors = %v, %v", first.err, second.err)
 	}
@@ -5088,11 +5165,13 @@ func (fs *blockingLinkVFS) LinkFile(
 	name string,
 	data io.Reader,
 ) error {
-	fs.enter()
+	if err := fs.enter(); err != nil {
+		return err
+	}
 	return fs.TernVFS.LinkFile(fileID, cookie, dirID, name, data)
 }
 
-func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
+func TestConcurrentCloseIsAtMostOnceAndReplayed(t *testing.T) {
 	fs := &blockingLinkVFS{
 		TernVFS: NewLocalTernVFS(t.TempDir()),
 		blockingVFSGate: blockingVFSGate{
@@ -5100,6 +5179,7 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 			releaseFirst: make(chan struct{}),
 		},
 	}
+	defer closeSignal(fs.releaseFirst)
 	localStaging, err := NewLocalStagingStore(t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -5130,22 +5210,27 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 	results := make(chan closeResult, 2)
 	go func() {
 		closeXID := uint32(100)
-		status, err := closeFileWithSeqStatusE(
+		status, result, err := closeFileWithSeqResultE(
 			firstConn, &closeXID, fh, stateid, 3)
-		results <- closeResult{status: status, err: err}
+		results <- closeResult{
+			status: status, stateid: result, err: err,
+		}
 	}()
-	<-fs.firstEntered
+	awaitSignal(t, fs.firstEntered, "first CLOSE entering LinkFile")
 	secondRequestEntered := staging.notifyNextGetMeta()
 	go func() {
 		closeXID := uint32(200)
-		status, err := closeFileWithSeqStatusE(
+		status, result, err := closeFileWithSeqResultE(
 			secondConn, &closeXID, fh, stateid, 3)
-		results <- closeResult{status: status, err: err}
+		results <- closeResult{
+			status: status, stateid: result, err: err,
+		}
 	}()
-	<-secondRequestEntered
-	close(fs.releaseFirst)
-	first := <-results
-	second := <-results
+	awaitSignal(t, secondRequestEntered,
+		"second CLOSE reading staging metadata")
+	closeSignal(fs.releaseFirst)
+	first := awaitValue(t, results, "first concurrent CLOSE result")
+	second := awaitValue(t, results, "second concurrent CLOSE result")
 
 	if first.err != nil || second.err != nil {
 		t.Fatalf("concurrent CLOSE errors = %v, %v", first.err, second.err)
@@ -5154,6 +5239,10 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 		t.Fatalf("concurrent CLOSE statuses = %s, %s",
 			Nfsstat4Name(first.status), Nfsstat4Name(second.status))
 	}
+	if first.stateid != second.stateid {
+		t.Fatalf("concurrent CLOSE stateids = %x, %x",
+			first.stateid, second.stateid)
+	}
 	if calls := fs.callCount(); calls != 1 {
 		t.Fatalf("LinkFile calls = %d, want 1", calls)
 	}
@@ -5161,20 +5250,29 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 
 func TestCloseUnknownStateid(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	if err := os.WriteFile(
+		filepath.Join(dir, "file.txt"), []byte("data"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	srv, addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
 
-	// Construct a filehandle for a nonexistent inode. Use a type=file inode
-	// with a made-up number that doesn't correspond to any real file.
-	var fakeFH [8]byte
-	fakeID := MakeInodeID(InodeTypeFile, 0xDEADDEAD)
-	binary.BigEndian.PutUint64(fakeFH[:], uint64(fakeID))
-	var fakeStateid [16]byte // all zeros
+	fileID, err := srv.fs.Lookup(srv.fs.RootID(), "file.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fh := binary.BigEndian.AppendUint64(nil, uint64(fileID))
+	var unknown [16]byte
+	binary.BigEndian.PutUint32(unknown[:4], 1)
+	for i := 4; i < len(unknown); i++ {
+		unknown[i] = 0xa5
+	}
 
 	xid := uint32(1)
-	status := closeFileWithSeqStatus(t, conn, &xid, fakeFH[:], fakeStateid, 3)
+	status := closeFileWithSeqStatus(t, conn, &xid, fh, unknown, 1)
 	if status != NFS4ERR_BAD_STATEID {
 		t.Fatalf("expected NFS4ERR_BAD_STATEID, got %s", Nfsstat4Name(status))
 	}
@@ -5839,7 +5937,7 @@ func TestRecoveredCloseOperationsAreStateidScoped(t *testing.T) {
 		}
 		started <- second
 	}()
-	<-attempting
+	awaitSignal(t, attempting, "second recovered CLOSE attempt")
 
 	var second *recoveredCloseOperation
 	select {
@@ -5952,17 +6050,23 @@ func restartWithStagedWrite(
 func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
 	data := []byte("staged across an nfsd restart")
 	restarted := restartWithStagedWrite(t, "recovered.txt", data)
-	if status := closeFileWithSeqStatus(
+	status, first := closeFileWithSeqResult(
 		t, restarted.conn, &restarted.xid, restarted.fh,
 		restarted.stateid, 3,
-	); status != NFS4_OK {
+	)
+	if status != NFS4_OK {
 		t.Fatalf("recovered CLOSE = %s", Nfsstat4Name(status))
 	}
-	if status := closeFileWithSeqStatus(
+	status, replay := closeFileWithSeqResult(
 		t, restarted.conn, &restarted.xid, restarted.fh,
 		restarted.stateid, 3,
-	); status != NFS4_OK {
+	)
+	if status != NFS4_OK {
 		t.Fatalf("recovered CLOSE replay = %s", Nfsstat4Name(status))
+	}
+	if replay != first {
+		t.Fatalf("recovered CLOSE replay stateid = %x, want %x",
+			replay, first)
 	}
 	got, err := os.ReadFile(filepath.Join(restarted.rootDir, "recovered.txt"))
 	if err != nil {

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -111,17 +111,36 @@ func buildCompoundBody(tag []byte, build func(w *COMPOUND4argsWriter)) []byte {
 // sendCompound builds a compound, sends it, and returns the parsed COMPOUND4res.
 func sendCompound(t *testing.T, conn net.Conn, xid uint32, build func(w *COMPOUND4argsWriter)) COMPOUND4res {
 	t.Helper()
-	body := buildCompoundBody(nil, build)
-	reply, err := sendRPC(conn, xid, procCompound, body)
+	res, err := sendCompoundE(conn, xid, build)
 	if err != nil {
 		t.Fatal(err)
 	}
-	nfsBody := parseRPCReply(t, reply)
-	res, ok := ReadCOMPOUND4res(nfsBody)
-	if !ok {
-		t.Fatal("failed to parse COMPOUND4res")
-	}
 	return res
+}
+
+func sendCompoundE(
+	conn net.Conn,
+	xid uint32,
+	build func(w *COMPOUND4argsWriter),
+) (COMPOUND4res, error) {
+	body := buildCompoundBody(nil, build)
+	reply, err := sendRPC(conn, xid, procCompound, body)
+	if err != nil {
+		return COMPOUND4res{}, err
+	}
+	if len(reply) < 24 {
+		return COMPOUND4res{}, fmt.Errorf(
+			"RPC reply too short: %d bytes", len(reply))
+	}
+	if acceptStat := binary.BigEndian.Uint32(reply[20:24]); acceptStat != 0 {
+		return COMPOUND4res{}, fmt.Errorf(
+			"RPC accept_stat = %d, want SUCCESS", acceptStat)
+	}
+	res, ok := ReadCOMPOUND4res(reply[24:])
+	if !ok {
+		return COMPOUND4res{}, errors.New("failed to parse COMPOUND4res")
+	}
+	return res, nil
 }
 
 func TestEmptyCompound(t *testing.T) {
@@ -212,12 +231,25 @@ func getAttrData(t *testing.T, getattrOk GETATTR4resok) []byte {
 	return getattrOk.ObjAttributes().AttrVals().Data()
 }
 
-// setupClient runs SETCLIENTID + SETCLIENTID_CONFIRM and returns the assigned clientid.
+// setupClient runs SETCLIENTID + SETCLIENTID_CONFIRM with a zero verifier.
 func setupClient(t *testing.T, conn net.Conn, xid *uint32) uint64 {
+	t.Helper()
+	return setupClientWithVerifier(t, conn, xid, [8]byte{})
+}
+
+func setupClientWithVerifier(
+	t *testing.T,
+	conn net.Conn,
+	xid *uint32,
+	verifier [8]byte,
+) uint64 {
 	t.Helper()
 	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
 		scw := w.AppendArgarray_Setclientid()
 		clientW := scw.StartClient()
+		for i, value := range verifier {
+			clientW.Verifier().SetData(i, value)
+		}
 		clientW = clientW.SetId([]byte("test-client"))
 		buf := clientW.Finish()
 		scw.Resume(buf)
@@ -997,10 +1029,7 @@ func TestOpenConfirmClose(t *testing.T) {
 		pw.Resume(buf)
 		w.Resume(pw.Finish())
 		rw := w.AppendArgarray_Read()
-		rw.Stateid().SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			rw.Stateid().SetOther(i, stateid[4+i])
-		}
+		setStateid(rw.Stateid(), stateid)
 		rw.SetOffset(0)
 		rw.SetCount(1024)
 	})
@@ -2709,11 +2738,7 @@ func TestWriteAndRead(t *testing.T) {
 		w.Resume(buf)
 
 		ww := w.AppendArgarray_Write()
-		sid := ww.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(openStateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid[4+i])
-		}
+		setStateid(ww.Stateid(), openStateid)
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(2) // FILE_SYNC4
 		ww = ww.SetData(writeData)
@@ -2770,11 +2795,7 @@ func TestStagedFileGetattrAndRead(t *testing.T) {
 		w.Resume(buf)
 
 		ww := w.AppendArgarray_Write()
-		sid := ww.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(openStateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, openStateid[4+i])
-		}
+		setStateid(ww.Stateid(), openStateid)
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(2)
 		ww = ww.SetData(writeData)
@@ -3224,11 +3245,7 @@ func confirmOpenState(
 		pw.Resume(buf)
 		w.Resume(pw.Finish())
 		confirmW := w.AppendArgarray_OpenConfirm()
-		sid := confirmW.OpenStateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(confirmW.OpenStateid(), stateid)
 		confirmW.SetSeqid(seqid)
 	})
 	*xid++
@@ -3245,6 +3262,13 @@ func confirmOpenState(
 	return confirmed
 }
 
+func setStateid(dst Stateid4, stateid [16]byte) {
+	dst.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
+	for i := range 12 {
+		dst.SetOther(i, stateid[4+i])
+	}
+}
+
 func openFileForOwner(
 	t *testing.T,
 	conn net.Conn,
@@ -3258,7 +3282,26 @@ func openFileForOwner(
 	guarded bool,
 ) (status uint32, stateid [16]byte, fh []byte, rflags uint32) {
 	t.Helper()
-	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
+	status, stateid, fh, rflags, err := openFileForOwnerE(
+		conn, xid, clientID, owner, seq, filename, access, create, guarded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return status, stateid, fh, rflags
+}
+
+func openFileForOwnerE(
+	conn net.Conn,
+	xid *uint32,
+	clientID uint64,
+	owner string,
+	seq uint32,
+	filename string,
+	access uint32,
+	create bool,
+	guarded bool,
+) (status uint32, stateid [16]byte, fh []byte, rflags uint32, err error) {
+	res, err := sendCompoundE(conn, *xid, func(w *COMPOUND4argsWriter) {
 		w.AppendArgarray_Putrootfh()
 		ow := w.AppendArgarray_Open()
 		ow.SetSeqid(seq)
@@ -3295,62 +3338,44 @@ func openFileForOwner(
 		w.AppendArgarray_Getfh()
 	})
 	*xid++
-	if res.Status() != NFS4_OK {
-		return res.Status(), stateid, nil, 0
+	if err != nil {
+		return 0, stateid, nil, 0, err
 	}
-	iter := expectOK(t, res)
-	nextOp(t, &iter)
-	openEntry := nextOp(t, &iter)
+	if res.Status() != NFS4_OK {
+		return res.Status(), stateid, nil, 0, nil
+	}
+	iter := res.Resarray()
+	if !iter.Next() || !iter.Next() {
+		return 0, stateid, nil, 0, errors.New(
+			"OPEN response is missing PUTROOTFH or OPEN")
+	}
+	openEntry := iter.Resarray()
 	openOK := openEntry.Value().AsOPEN4resEntry().Value().AsOPEN4resok()
 	sid := openOK.Stateid()
 	binary.BigEndian.PutUint32(stateid[:4], sid.Seqid())
 	for i := 0; i < 12; i++ {
 		stateid[4+i] = sid.Other(i)
 	}
-	fhEntry := nextOp(t, &iter)
+	if !iter.Next() {
+		return 0, stateid, nil, 0, errors.New(
+			"OPEN response is missing GETFH")
+	}
+	fhEntry := iter.Resarray()
 	fh = append([]byte(nil), fhEntry.Value().AsGETFH4resEntry().
 		Value().AsGETFH4resok().Object().Data()...)
-	return NFS4_OK, stateid, fh, openOK.Rflags()
+	return NFS4_OK, stateid, fh, openOK.Rflags(), nil
 }
 
 // openReadFile opens a file for read and returns the open stateid and filehandle.
 func openReadFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, filename string) (stateid [16]byte, fh []byte) {
 	t.Helper()
-	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_READ)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner-" + filename))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		ow.SetOpenhow_Default(OPEN4_NOCREATE)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte(filename)).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-		w.AppendArgarray_Getfh()
-	})
-	*xid++
-	iter := expectOK(t, res)
-	nextOp(t, &iter) // PUTROOTFH
-	entry := nextOp(t, &iter)
-	openRes := entry.Value().AsOPEN4resEntry()
-	if openRes.Disc() != NFS4_OK {
-		t.Fatalf("OPEN status = %s", Nfsstat4Name(openRes.Disc()))
+	status, stateid, fh, _ := openFileForOwner(
+		t, conn, xid, clientid, "test-owner-"+filename, 1, filename,
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
 	}
-	openOk := openRes.Value().AsOPEN4resok()
-	sid := openOk.Stateid()
-	binary.BigEndian.PutUint32(stateid[0:4], sid.Seqid())
-	for i := 0; i < 12; i++ {
-		stateid[4+i] = sid.Other(i)
-	}
-	entry = nextOp(t, &iter)
-	fh = append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
 	stateid = confirmOpenState(t, conn, xid, fh, 2, stateid)
 	return stateid, fh
 }
@@ -3358,52 +3383,13 @@ func openReadFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, fil
 // openCreateFile opens a new file for write and returns the open stateid and filehandle.
 func openCreateFile(t *testing.T, conn net.Conn, xid *uint32, clientid uint64, filename string) (stateid [16]byte, fh []byte) {
 	t.Helper()
-	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_BOTH)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner-" + filename))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		chw := ow.SetOpenhow_Create()
-		faw := chw.SetValue_Unchecked4()
-		bmW := faw.StartAttrmask()
-		buf = bmW.Finish()
-		faw.Resume(buf)
-		alW := faw.StartAttrVals()
-		buf = alW.SetData(nil).Finish()
-		faw.Resume(buf)
-		buf = faw.Finish()
-		chw.Resume(buf)
-		buf = chw.Finish()
-		ow.Resume(buf)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte(filename)).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-		w.AppendArgarray_Getfh()
-	})
-	*xid++
-	iter := expectOK(t, res)
-	nextOp(t, &iter) // PUTROOTFH
-	entry := nextOp(t, &iter)
-	openRes := entry.Value().AsOPEN4resEntry()
-	if openRes.Disc() != NFS4_OK {
-		t.Fatalf("OPEN CREATE status = %s", Nfsstat4Name(openRes.Disc()))
+	status, stateid, fh, _ := openFileForOwner(
+		t, conn, xid, clientid, "test-owner-"+filename, 1, filename,
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN CREATE status = %s", Nfsstat4Name(status))
 	}
-	openOk := openRes.Value().AsOPEN4resok()
-	sid := openOk.Stateid()
-	binary.BigEndian.PutUint32(stateid[0:4], sid.Seqid())
-	for i := 0; i < 12; i++ {
-		stateid[4+i] = sid.Other(i)
-	}
-	entry = nextOp(t, &iter)
-	fh = append([]byte(nil), entry.Value().AsGETFH4resEntry().Value().AsGETFH4resok().Object().Data()...)
 	stateid = confirmOpenState(t, conn, xid, fh, 2, stateid)
 	return stateid, fh
 }
@@ -3426,7 +3412,21 @@ func closeFileWithSeqStatus(
 	seq uint32,
 ) uint32 {
 	t.Helper()
-	res := sendCompound(t, conn, *xid, func(w *COMPOUND4argsWriter) {
+	status, err := closeFileWithSeqStatusE(conn, xid, fh, stateid, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return status
+}
+
+func closeFileWithSeqStatusE(
+	conn net.Conn,
+	xid *uint32,
+	fh []byte,
+	stateid [16]byte,
+	seq uint32,
+) (uint32, error) {
+	res, err := sendCompoundE(conn, *xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
 		fhW := pw.StartObject()
 		buf := fhW.SetData(fh).Finish()
@@ -3435,20 +3435,13 @@ func closeFileWithSeqStatus(
 		w.Resume(buf)
 		caw := w.AppendArgarray_Close()
 		caw.SetSeqid(seq)
-		sid := caw.OpenStateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(caw.OpenStateid(), stateid)
 	})
 	*xid++
-	return res.Status()
-}
-
-// closeFileExpectStatus sends CLOSE and returns the NFS status.
-func closeFileExpectStatus(t *testing.T, conn net.Conn, xid *uint32, fh []byte, stateid [16]byte) uint32 {
-	t.Helper()
-	return closeFileWithSeqStatus(t, conn, xid, fh, stateid, 3)
+	if err != nil {
+		return 0, err
+	}
+	return res.Status(), nil
 }
 
 // collectReaddirNames issues READDIR calls to collect all names in a directory.
@@ -3533,7 +3526,6 @@ func collectReaddirNames(t *testing.T, conn net.Conn, xid *uint32, dirFH []byte)
 // [x] TestCommitVerifier — COMMIT returns write verifier
 // [x] TestReadOnlyMode — no staging → NFS4ERR_ROFS
 // [x] TestLockNotSupported — LOCK/LOCKT/LOCKU → NFS4ERR_NOTSUPP
-// [x] TestOpenStateStoreIssuesUniqueStateids — each OPEN gets unique state
 // [x] TestSetclientidReboot — same identity, different verifier
 
 func TestReaddirPagination(t *testing.T) {
@@ -4033,11 +4025,7 @@ func TestSetattrSize(t *testing.T) {
 		buf = pw.Finish()
 		w.Resume(buf)
 		ww := w.AppendArgarray_Write()
-		sid := ww.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(ww.Stateid(), stateid)
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(2)
 		ww = ww.SetData(writeData)
@@ -4056,11 +4044,7 @@ func TestSetattrSize(t *testing.T) {
 		buf = pw.Finish()
 		w.Resume(buf)
 		saw := w.AppendArgarray_Setattr()
-		sid := saw.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(saw.Stateid(), stateid)
 		faw := saw.StartObjAttributes()
 		bmW := faw.StartAttrmask()
 		bmW.AppendData(1 << FATTR4_SIZE)
@@ -4115,11 +4099,7 @@ func TestSetattrSizeRequiresWriteOpen(t *testing.T) {
 		w.Resume(pw.Finish())
 
 		saw := w.AppendArgarray_Setattr()
-		sid := saw.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(saw.Stateid(), stateid)
 		faw := saw.StartObjAttributes()
 		bmW := faw.StartAttrmask()
 		bmW.AppendData(1 << FATTR4_SIZE)
@@ -4309,7 +4289,7 @@ func TestCloseReplay(t *testing.T) {
 	}
 
 	// Send CLOSE again (replay). Should succeed.
-	status := closeFileExpectStatus(t, conn, &xid, fh, stateid)
+	status := closeFileWithSeqStatus(t, conn, &xid, fh, stateid, 3)
 	if status != NFS4_OK {
 		t.Fatalf("CLOSE replay: expected NFS4_OK, got %s", Nfsstat4Name(status))
 	}
@@ -4350,12 +4330,17 @@ func TestFailedOpenAdvancesOwnerSeqid(t *testing.T) {
 			Nfsstat4Name(status))
 	}
 	status, _, _, _ = openFileForOwner(
-		t, conn, &xid, clientID, "shared-owner", 3, "existing.txt",
+		t, conn, &xid, clientID, "shared-owner", 3, "would-succeed.txt",
 		OPEN4_SHARE_ACCESS_BOTH, true, true,
 	)
 	if status != NFS4ERR_EXIST {
 		t.Fatalf("guarded OPEN replay = %s, want NFS4ERR_EXIST",
 			Nfsstat4Name(status))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "would-succeed.txt")); !errors.Is(
+		err, os.ErrNotExist,
+	) {
+		t.Fatalf("replayed failed OPEN created a file: %v", err)
 	}
 	if status := closeFileWithSeqStatus(
 		t, conn, &xid, fh, stateid, 4,
@@ -4412,39 +4397,219 @@ func TestOnlyFirstOpenRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestOpenUpgradeReusesState(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "file.txt"), []byte("data"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(NewLocalTernVFS(dir), staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, first, fh, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 1, "file.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK || flags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatalf("first OPEN status = %s, rflags = %#x",
+			Nfsstat4Name(status), flags)
+	}
+	first = confirmOpenState(t, conn, &xid, fh, 2, first)
+
+	status, upgraded, upgradedFH, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 3, "file.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
+	}
+	if flags&OPEN4_RESULT_CONFIRM != 0 {
+		t.Fatal("second OPEN unnecessarily required confirmation")
+	}
+	if !bytes.Equal(first[4:], upgraded[4:]) {
+		t.Fatalf("second OPEN stateid other = %x, want %x",
+			upgraded[4:], first[4:])
+	}
+	if got := binary.BigEndian.Uint32(upgraded[:4]); got != 3 {
+		t.Fatalf("second OPEN generation = %d, want 3", got)
+	}
+	if !bytes.Equal(upgradedFH, fh) {
+		t.Fatal("second OPEN returned a different filehandle")
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, upgraded, 4,
+	); status != NFS4_OK {
+		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
+	}
+	srv.opens.mu.Lock()
+	defer srv.opens.mu.Unlock()
+	if len(srv.opens.states) != 0 {
+		t.Fatalf("states after CLOSE = %d, want 0", len(srv.opens.states))
+	}
+}
+
+func TestReadCloseAfterFileRemoval(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(NewLocalTernVFS(dir), staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	stateid, fh := openReadFile(t, conn, &xid, clientID, "file.txt")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 3,
+	); status != NFS4_OK {
+		t.Fatalf("CLOSE after removal = %s, want NFS4_OK",
+			Nfsstat4Name(status))
+	}
+	srv.opens.mu.Lock()
+	defer srv.opens.mu.Unlock()
+	if len(srv.opens.states) != 0 {
+		t.Fatalf("states after CLOSE = %d, want 0", len(srv.opens.states))
+	}
+}
+
+func TestUnconfirmedOwnerOutOfSequenceOpen(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "second.txt"), []byte("data"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	fs := NewLocalTernVFS(dir)
+	staging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(fs, staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	conn := dial(t, addr)
+	defer conn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, conn, &xid)
+	status, first, firstFH, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 1, "first.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK || flags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatalf("first OPEN status = %s, rflags = %#x",
+			Nfsstat4Name(status), flags)
+	}
+	firstID, ok := fhToInodeID(firstFH)
+	if !ok {
+		t.Fatal("invalid filehandle returned by first OPEN")
+	}
+	if staging.Get(firstID) == nil {
+		t.Fatal("first OPEN did not create staging")
+	}
+
+	status, second, secondFH, flags := openFileForOwner(
+		t, conn, &xid, clientID, "shared-owner", 7, "second.txt",
+		OPEN4_SHARE_ACCESS_READ, false, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("out-of-sequence OPEN = %s, want NFS4_OK",
+			Nfsstat4Name(status))
+	}
+	if flags&OPEN4_RESULT_CONFIRM == 0 {
+		t.Fatal("replacement OPEN did not require confirmation")
+	}
+	if staging.Get(firstID) != nil {
+		t.Fatal("replacement OPEN retained abandoned staging")
+	}
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, firstFH, first, 8,
+	); status != NFS4ERR_BAD_STATEID {
+		t.Fatalf("abandoned stateid CLOSE = %s, want NFS4ERR_BAD_STATEID",
+			Nfsstat4Name(status))
+	}
+
+	second = confirmOpenState(t, conn, &xid, secondFH, 8, second)
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, secondFH, second, 9,
+	); status != NFS4_OK {
+		t.Fatalf("replacement CLOSE = %s", Nfsstat4Name(status))
+	}
+}
+
+type blockingVFSGate struct {
+	mu           sync.Mutex
+	calls        int
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+}
+
+func (gate *blockingVFSGate) enter() {
+	gate.mu.Lock()
+	gate.calls++
+	call := gate.calls
+	gate.mu.Unlock()
+	if call == 1 {
+		close(gate.firstEntered)
+		<-gate.releaseFirst
+	}
+}
+
+func (gate *blockingVFSGate) callCount() int {
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+	return gate.calls
+}
+
 type blockingConstructVFS struct {
 	TernVFS
-
-	mu            sync.Mutex
-	calls         int
-	firstEntered  chan struct{}
-	secondEntered chan struct{}
-	releaseFirst  chan struct{}
+	blockingVFSGate
 }
 
 func (fs *blockingConstructVFS) ConstructFile(
 	dirID InodeID,
 ) (InodeID, Cookie, error) {
-	fs.mu.Lock()
-	fs.calls++
-	call := fs.calls
-	fs.mu.Unlock()
-	switch call {
-	case 1:
-		close(fs.firstEntered)
-		<-fs.releaseFirst
-	case 2:
-		close(fs.secondEntered)
-	}
+	fs.enter()
 	return fs.TernVFS.ConstructFile(dirID)
 }
 
 func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 	fs := &blockingConstructVFS{
-		TernVFS:       NewLocalTernVFS(t.TempDir()),
-		firstEntered:  make(chan struct{}),
-		secondEntered: make(chan struct{}),
-		releaseFirst:  make(chan struct{}),
+		TernVFS: NewLocalTernVFS(t.TempDir()),
+		blockingVFSGate: blockingVFSGate{
+			firstEntered: make(chan struct{}),
+			releaseFirst: make(chan struct{}),
+		},
 	}
 	staging, err := NewLocalStagingStore(t.TempDir(), nil)
 	if err != nil {
@@ -4467,31 +4632,32 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 		status  uint32
 		stateid [16]byte
 		fh      []byte
+		err     error
 	}
 	results := make(chan result, 2)
+	secondStarted := make(chan struct{})
 	open := func(conn net.Conn, xid uint32) {
-		status, stateid, fh, _ := openFileForOwner(
-			t, conn, &xid, clientID, "shared-owner", 1, "race.txt",
+		status, stateid, fh, _, err := openFileForOwnerE(
+			conn, &xid, clientID, "shared-owner", 1, "race.txt",
 			OPEN4_SHARE_ACCESS_BOTH, true, false,
 		)
-		results <- result{status: status, stateid: stateid, fh: fh}
+		results <- result{
+			status: status, stateid: stateid, fh: fh, err: err,
+		}
 	}
 	go open(firstConn, 100)
 	<-fs.firstEntered
-	go open(secondConn, 200)
-
-	concurrent := false
-	select {
-	case <-fs.secondEntered:
-		concurrent = true
-	case <-time.After(100 * time.Millisecond):
-	}
+	go func() {
+		close(secondStarted)
+		open(secondConn, 200)
+	}()
+	<-secondStarted
 	close(fs.releaseFirst)
 	first := <-results
 	second := <-results
 
-	if concurrent {
-		t.Fatal("retransmitted OPEN entered ConstructFile concurrently")
+	if first.err != nil || second.err != nil {
+		t.Fatalf("concurrent OPEN errors = %v, %v", first.err, second.err)
 	}
 	if first.status != NFS4_OK || second.status != NFS4_OK {
 		t.Fatalf("concurrent OPEN statuses = %s, %s",
@@ -4500,10 +4666,7 @@ func TestConcurrentOpenIsSerializedPerOwner(t *testing.T) {
 	if first.stateid != second.stateid || !bytes.Equal(first.fh, second.fh) {
 		t.Fatal("OPEN replay returned different state")
 	}
-	fs.mu.Lock()
-	calls := fs.calls
-	fs.mu.Unlock()
-	if calls != 1 {
+	if calls := fs.callCount(); calls != 1 {
 		t.Fatalf("ConstructFile calls = %d, want 1", calls)
 	}
 }
@@ -4513,6 +4676,11 @@ type failingLinkVFS struct {
 
 	mu        sync.Mutex
 	remaining int
+}
+
+type closeResult struct {
+	status uint32
+	err    error
 }
 
 func (fs *failingLinkVFS) LinkFile(
@@ -4530,6 +4698,132 @@ func (fs *failingLinkVFS) LinkFile(
 	}
 	fs.mu.Unlock()
 	return fs.TernVFS.LinkFile(fileID, cookie, dirID, name, data)
+}
+
+type blockingFailingLinkVFS struct {
+	TernVFS
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (fs *blockingFailingLinkVFS) LinkFile(
+	InodeID,
+	Cookie,
+	InodeID,
+	string,
+	io.Reader,
+) error {
+	close(fs.entered)
+	<-fs.release
+	return errors.New("injected LinkFile failure")
+}
+
+type notifyingStagingStore struct {
+	StagingStore
+
+	mu       sync.Mutex
+	calls    int
+	notifyAt int
+	notified chan struct{}
+}
+
+func (store *notifyingStagingStore) GetMeta(
+	id InodeID,
+) (StagingMeta, bool) {
+	store.mu.Lock()
+	store.calls++
+	if store.calls == store.notifyAt {
+		close(store.notified)
+	}
+	store.mu.Unlock()
+	return store.StagingStore.GetMeta(id)
+}
+
+func (store *notifyingStagingStore) notifyOnGetMeta(
+	call int,
+) <-chan struct{} {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.calls = 0
+	store.notifyAt = call
+	store.notified = make(chan struct{})
+	return store.notified
+}
+
+func TestWaitingCloseRechecksStagingMeta(t *testing.T) {
+	fs := &blockingFailingLinkVFS{
+		TernVFS: NewLocalTernVFS(t.TempDir()),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	localStaging, err := NewLocalStagingStore(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staging := &notifyingStagingStore{StagingStore: localStaging}
+	srv, err := NewServer(fs, staging, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, cleanup := serveTestServer(t, srv)
+	defer cleanup()
+	firstConn := dial(t, addr)
+	defer firstConn.Close()
+	secondConn := dial(t, addr)
+	defer secondConn.Close()
+
+	xid := uint32(1)
+	clientID := setupClient(t, firstConn, &xid)
+	status, stateid, fh, _ := openFileForOwner(
+		t, firstConn, &xid, clientID, "shared-owner", 1, "race.txt",
+		OPEN4_SHARE_ACCESS_BOTH, true, false,
+	)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
+	}
+	stateid = confirmOpenState(t, firstConn, &xid, fh, 2, stateid)
+
+	// The first CLOSE reads metadata twice before entering LinkFile. The
+	// third read proves the second CLOSE captured its recovery hint before
+	// waiting for the owner operation.
+	secondRead := staging.notifyOnGetMeta(3)
+	firstResult := make(chan closeResult, 1)
+	go func() {
+		closeXID := uint32(100)
+		status, err := closeFileWithSeqStatusE(
+			firstConn, &closeXID, fh, stateid, 3)
+		firstResult <- closeResult{status: status, err: err}
+	}()
+	<-fs.entered
+	secondResult := make(chan closeResult, 1)
+	go func() {
+		closeXID := uint32(200)
+		status, err := closeFileWithSeqStatusE(
+			secondConn, &closeXID, fh, stateid, 4)
+		secondResult <- closeResult{status: status, err: err}
+	}()
+	<-secondRead
+	close(fs.release)
+
+	first := <-firstResult
+	second := <-secondResult
+	if first.err != nil || second.err != nil {
+		t.Fatalf("CLOSE errors = %v, %v", first.err, second.err)
+	}
+	if first.status != NFS4ERR_IO {
+		t.Fatalf("first CLOSE = %s, want NFS4ERR_IO",
+			Nfsstat4Name(first.status))
+	}
+	if second.status != NFS4ERR_EXPIRED {
+		t.Fatalf("second CLOSE = %s, want NFS4ERR_EXPIRED",
+			Nfsstat4Name(second.status))
+	}
+	srv.opens.mu.Lock()
+	defer srv.opens.mu.Unlock()
+	if len(srv.opens.states) != 0 {
+		t.Fatalf("states after lost write = %d, want 0",
+			len(srv.opens.states))
+	}
 }
 
 func TestFailedCloseAdvancesAndReplaysOwnerSeqid(t *testing.T) {
@@ -4594,12 +4888,7 @@ func TestFailedCloseAdvancesAndReplaysOwnerSeqid(t *testing.T) {
 
 type blockingLinkVFS struct {
 	TernVFS
-
-	mu            sync.Mutex
-	calls         int
-	firstEntered  chan struct{}
-	secondEntered chan struct{}
-	releaseFirst  chan struct{}
+	blockingVFSGate
 }
 
 func (fs *blockingLinkVFS) LinkFile(
@@ -4609,26 +4898,17 @@ func (fs *blockingLinkVFS) LinkFile(
 	name string,
 	data io.Reader,
 ) error {
-	fs.mu.Lock()
-	fs.calls++
-	call := fs.calls
-	fs.mu.Unlock()
-	switch call {
-	case 1:
-		close(fs.firstEntered)
-		<-fs.releaseFirst
-	case 2:
-		close(fs.secondEntered)
-	}
+	fs.enter()
 	return fs.TernVFS.LinkFile(fileID, cookie, dirID, name, data)
 }
 
 func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 	fs := &blockingLinkVFS{
-		TernVFS:       NewLocalTernVFS(t.TempDir()),
-		firstEntered:  make(chan struct{}),
-		secondEntered: make(chan struct{}),
-		releaseFirst:  make(chan struct{}),
+		TernVFS: NewLocalTernVFS(t.TempDir()),
+		blockingVFSGate: blockingVFSGate{
+			firstEntered: make(chan struct{}),
+			releaseFirst: make(chan struct{}),
+		},
 	}
 	staging, err := NewLocalStagingStore(t.TempDir(), nil)
 	if err != nil {
@@ -4656,40 +4936,35 @@ func TestConcurrentCloseIsSerializedPerOwner(t *testing.T) {
 	}
 	stateid = confirmOpenState(t, firstConn, &xid, fh, 2, stateid)
 
-	statuses := make(chan uint32, 2)
+	results := make(chan closeResult, 2)
 	go func() {
 		closeXID := uint32(100)
-		statuses <- closeFileWithSeqStatus(
-			t, firstConn, &closeXID, fh, stateid, 3)
+		status, err := closeFileWithSeqStatusE(
+			firstConn, &closeXID, fh, stateid, 3)
+		results <- closeResult{status: status, err: err}
 	}()
 	<-fs.firstEntered
+	secondStarted := make(chan struct{})
 	go func() {
+		close(secondStarted)
 		closeXID := uint32(200)
-		statuses <- closeFileWithSeqStatus(
-			t, secondConn, &closeXID, fh, stateid, 3)
+		status, err := closeFileWithSeqStatusE(
+			secondConn, &closeXID, fh, stateid, 3)
+		results <- closeResult{status: status, err: err}
 	}()
-
-	concurrent := false
-	select {
-	case <-fs.secondEntered:
-		concurrent = true
-	case <-time.After(100 * time.Millisecond):
-	}
+	<-secondStarted
 	close(fs.releaseFirst)
-	firstStatus := <-statuses
-	secondStatus := <-statuses
+	first := <-results
+	second := <-results
 
-	if concurrent {
-		t.Fatal("retransmitted CLOSE entered LinkFile concurrently")
+	if first.err != nil || second.err != nil {
+		t.Fatalf("concurrent CLOSE errors = %v, %v", first.err, second.err)
 	}
-	if firstStatus != NFS4_OK || secondStatus != NFS4_OK {
+	if first.status != NFS4_OK || second.status != NFS4_OK {
 		t.Fatalf("concurrent CLOSE statuses = %s, %s",
-			Nfsstat4Name(firstStatus), Nfsstat4Name(secondStatus))
+			Nfsstat4Name(first.status), Nfsstat4Name(second.status))
 	}
-	fs.mu.Lock()
-	calls := fs.calls
-	fs.mu.Unlock()
-	if calls != 1 {
+	if calls := fs.callCount(); calls != 1 {
 		t.Fatalf("LinkFile calls = %d, want 1", calls)
 	}
 }
@@ -4709,7 +4984,7 @@ func TestCloseUnknownStateid(t *testing.T) {
 	var fakeStateid [16]byte // all zeros
 
 	xid := uint32(1)
-	status := closeFileExpectStatus(t, conn, &xid, fakeFH[:], fakeStateid)
+	status := closeFileWithSeqStatus(t, conn, &xid, fakeFH[:], fakeStateid, 3)
 	if status != NFS4ERR_BAD_STATEID {
 		t.Fatalf("expected NFS4ERR_BAD_STATEID, got %s", Nfsstat4Name(status))
 	}
@@ -4770,7 +5045,8 @@ func TestWriteSpecialStateid(t *testing.T) {
 
 	xid := uint32(1)
 	clientid := setupClient(t, conn, &xid)
-	_, fh := openCreateFile(t, conn, &xid, clientid, "specialwrite.txt")
+	stateid, fh := openCreateFile(
+		t, conn, &xid, clientid, "specialwrite.txt")
 
 	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
@@ -4792,6 +5068,14 @@ func TestWriteSpecialStateid(t *testing.T) {
 	xid++
 
 	expectOK(t, res)
+	closeFile(t, conn, &xid, fh, stateid)
+	data, err := os.ReadFile(filepath.Join(dir, "specialwrite.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("file content = %q, want %q", data, "hello")
+	}
 }
 
 // TestSetattrSizeSpecialStateid verifies that SETATTR(SIZE) accepts the
@@ -4807,7 +5091,8 @@ func TestSetattrSizeSpecialStateid(t *testing.T) {
 
 	xid := uint32(1)
 	clientid := setupClient(t, conn, &xid)
-	_, fh := openCreateFile(t, conn, &xid, clientid, "specialsetattr.txt")
+	stateid, fh := openCreateFile(
+		t, conn, &xid, clientid, "specialsetattr.txt")
 
 	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
@@ -4823,7 +5108,6 @@ func TestSetattrSizeSpecialStateid(t *testing.T) {
 		faw := saw.StartObjAttributes()
 		bmW := faw.StartAttrmask()
 		bmW.AppendData(1 << FATTR4_SIZE)
-		bmW.AppendData(0)
 		buf = bmW.Finish()
 		faw.Resume(buf)
 		attrData := make([]byte, 8)
@@ -4841,6 +5125,14 @@ func TestSetattrSizeSpecialStateid(t *testing.T) {
 	if res.Status() != NFS4_OK {
 		t.Fatalf("SETATTR(SIZE) with special stateid: status = %s, want NFS4_OK",
 			Nfsstat4Name(res.Status()))
+	}
+	closeFile(t, conn, &xid, fh, stateid)
+	info, err := os.Stat(filepath.Join(dir, "specialsetattr.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 10 {
+		t.Fatalf("file size = %d, want 10", info.Size())
 	}
 }
 
@@ -4865,11 +5157,7 @@ func TestCommitVerifier(t *testing.T) {
 		buf = pw.Finish()
 		w.Resume(buf)
 		ww := w.AppendArgarray_Write()
-		sid := ww.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[0:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(ww.Stateid(), stateid)
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(0) // UNSTABLE4
 		ww = ww.SetData([]byte("commit test"))
@@ -5019,85 +5307,41 @@ func TestLockNotSupported(t *testing.T) {
 	}
 }
 
-func TestOpenStateStoreIssuesUniqueStateids(t *testing.T) {
-	store := newOpenStateStore()
-	fileID := MakeInodeID(InodeTypeFile, 1)
-	first, status := store.addOpen(
-		openOwnerKey{clientID: 1, owner: "first"},
-		1, fileID, false, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatalf("first OPEN status = %s", Nfsstat4Name(status))
-	}
-	second, status := store.addOpen(
-		openOwnerKey{clientID: 1, owner: "second"},
-		1, fileID, false, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
-	}
-	if first.id == second.id {
-		t.Fatalf("OPEN stateids are identical: %x", first.id)
-	}
-}
-
-func TestOpenStateStoreValidation(t *testing.T) {
+func TestOpenStateStoreCloseChecksSeqidBeforeStateid(t *testing.T) {
 	store := newOpenStateStore()
 	owner := openOwnerKey{clientID: 7, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
-	state, status := store.addOpen(
-		owner, 1, fileID, false, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
-	}
-	if _, status = store.confirm(state.id, 1, fileID, 2); status != NFS4_OK {
-		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
-	}
-	if _, _, status = store.validateClose(
+	state := addConfirmedOpen(t, store, owner, fileID)
+	if _, _, status := store.validateClose(
 		state.id, 1, fileID, 50,
 	); status != NFS4ERR_BAD_SEQID {
 		t.Fatalf("CLOSE error priority status = %s, want NFS4ERR_BAD_SEQID",
 			Nfsstat4Name(status))
 	}
-	if _, status = store.lookup(state.id, 1, fileID); status != NFS4ERR_OLD_STATEID {
+}
+
+func TestOpenStateStoreLookupClassifiesStateids(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 7, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state := addConfirmedOpen(t, store, owner, fileID)
+	if _, status := store.lookup(
+		state.id, 1, fileID,
+	); status != NFS4ERR_OLD_STATEID {
 		t.Fatalf("old stateid status = %s", Nfsstat4Name(status))
 	}
 
 	stale := state.id
 	binary.BigEndian.PutUint32(stale[0:4], 1)
-	if _, status = store.lookup(stale, 2, fileID); status != NFS4ERR_STALE_STATEID {
+	if _, status := store.lookup(
+		stale, 2, fileID,
+	); status != NFS4ERR_STALE_STATEID {
 		t.Fatalf("stale stateid status = %s", Nfsstat4Name(status))
 	}
-	if _, status = store.lookup(StateID{}, 0, fileID); status != NFS4ERR_BAD_STATEID {
+	if _, status := store.lookup(
+		StateID{}, 0, fileID,
+	); status != NFS4ERR_BAD_STATEID {
 		t.Fatalf("unknown stateid status = %s", Nfsstat4Name(status))
-	}
-
-	if _, _, status = store.validateClose(
-		state.id, 2, fileID, 50,
-	); status != NFS4ERR_BAD_SEQID {
-		t.Fatalf("bad CLOSE seqid status = %s", Nfsstat4Name(status))
-	}
-	closeState, replay, status := store.validateClose(
-		state.id, 2, fileID, 3,
-	)
-	if status != NFS4_OK || replay {
-		t.Fatalf("CLOSE validation status = %s, replay = %t",
-			Nfsstat4Name(status), replay)
-	}
-	if _, status = store.close(closeState.id, 3); status != NFS4_OK {
-		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
-	}
-	if _, replay, status = store.validateClose(
-		state.id, 2, fileID, 3,
-	); status != NFS4_OK || !replay {
-		t.Fatalf("CLOSE replay status = %s, replay = %t",
-			Nfsstat4Name(status), replay)
-	}
-
-	store.purgeClient(owner.clientID)
-	if _, status = store.lookup(state.id, 3, fileID); status != NFS4ERR_EXPIRED {
-		t.Fatalf("expired stateid status = %s", Nfsstat4Name(status))
 	}
 }
 
@@ -5123,24 +5367,47 @@ func TestOpenStateStoreReplay(t *testing.T) {
 	if _, status = store.confirm(state.id, 1, fileID, 5); status != NFS4_OK {
 		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
 	}
-	confirmed, status := store.confirm(state.id, 1, fileID, 5)
-	if status != NFS4_OK || confirmed.generation != 2 {
-		t.Fatalf("OPEN_CONFIRM replay status = %s, generation = %d",
-			Nfsstat4Name(status), confirmed.generation)
-	}
 	if _, replay, status = store.beginOpen(owner, 4); status != NFS4ERR_BAD_SEQID {
 		t.Fatalf("old OPEN seqid status = %s, replay = %t",
 			Nfsstat4Name(status), replay)
 	}
+	secondOwner := openOwnerKey{clientID: 1, owner: "second"}
 	second, status := store.addOpen(
-		openOwnerKey{clientID: 1, owner: "second"},
-		1, fileID, false, StateID{},
+		secondOwner, 1, fileID, false, StateID{},
 	)
 	if status != NFS4_OK {
 		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
 	}
-	if second.fileID != fileID {
-		t.Fatalf("second OPEN file = %v, want %v", second.fileID, fileID)
+	if second.id == state.id {
+		t.Fatalf("second owner replayed first owner stateid %x", state.id)
+	}
+	replayed, replay, status = store.beginOpen(secondOwner, 1)
+	if status != NFS4_OK || !replay || replayed.id != second.id {
+		t.Fatalf("second owner replay status = %s, replay = %t, stateid = %x",
+			Nfsstat4Name(status), replay, replayed.id)
+	}
+}
+
+func TestOpenStateStoreNonExemptCloseErrorAdvancesSeqid(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 1, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state := addConfirmedOpen(t, store, owner, fileID)
+	if _, _, status := store.validateClose(
+		state.id, 1, fileID, 3,
+	); status != NFS4ERR_OLD_STATEID {
+		t.Fatalf("old CLOSE stateid = %s, want NFS4ERR_OLD_STATEID",
+			Nfsstat4Name(status))
+	}
+	if _, _, status := store.validateClose(
+		state.id, 2, fileID, 3,
+	); status != NFS4ERR_BAD_SEQID {
+		t.Fatalf("reused CLOSE seqid = %s, want NFS4ERR_BAD_SEQID",
+			Nfsstat4Name(status))
+	}
+	if _, status := store.close(state.id, 4); status != NFS4_OK {
+		t.Fatalf("advanced CLOSE = %s, want NFS4_OK",
+			Nfsstat4Name(status))
 	}
 }
 
@@ -5230,12 +5497,11 @@ func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
 		states = append(states, state)
 	}
 
-	for range 10 {
-		if _, status := store.lookup(
-			states[0].id, 2, states[0].fileID,
-		); status != NFS4_OK {
-			t.Fatal(Nfsstat4Name(status))
-		}
+	if _, status := store.close(states[0].id, 3); status != NFS4_OK {
+		t.Fatalf("first owner CLOSE = %s", Nfsstat4Name(status))
+	}
+	if len(store.states) != 1 {
+		t.Fatalf("states after CLOSE = %d, want 1", len(store.states))
 	}
 	if _, status := store.lookup(
 		states[1].id, 2, states[1].fileID,
@@ -5245,12 +5511,46 @@ func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
 	}
 
 	store.purgeClient(clientID)
-	for _, state := range states {
-		if _, status := store.lookup(
-			state.id, 2, state.fileID,
-		); status != NFS4ERR_EXPIRED {
-			t.Fatalf("reboot-purged state = %s", Nfsstat4Name(status))
-		}
+	if len(store.states) != 0 || len(store.owners) != 0 {
+		t.Fatalf("reboot retained states=%d owners=%d",
+			len(store.states), len(store.owners))
+	}
+}
+
+func TestPurgeClientReturnsOnlyWriteFiles(t *testing.T) {
+	store := newOpenStateStore()
+	clientID := uint64(1)
+	readID := MakeInodeID(InodeTypeFile, 1)
+	writeID := MakeInodeID(InodeTypeFile, 2)
+	readState, status := store.addOpen(
+		openOwnerKey{clientID: clientID, owner: "read"},
+		1, readID, false, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		readState.id, 1, readID, 2,
+	); status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	writeState, status := store.addOpen(
+		openOwnerKey{clientID: clientID, owner: "write"},
+		1, writeID, true, StateID{},
+	)
+	if status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if _, status = store.confirm(
+		writeState.id, 1, writeID, 2,
+	); status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+
+	fileIDs := store.purgeClient(clientID)
+	if len(fileIDs) != 1 || fileIDs[0] != writeID {
+		t.Fatalf("purged staging file IDs = %v, want [%v]",
+			fileIDs, writeID)
 	}
 }
 
@@ -5258,7 +5558,7 @@ func TestOpenStateStoreBoundsRebootTombstones(t *testing.T) {
 	store := newOpenStateStore()
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	var firstStateID StateID
-	for i := 0; i <= maxRecoveredCloseResponses; i++ {
+	for i := 0; i <= maxTombstones; i++ {
 		clientID := uint64(i + 1)
 		state, status := store.addOpen(
 			openOwnerKey{clientID: clientID, owner: "owner"},
@@ -5272,42 +5572,19 @@ func TestOpenStateStoreBoundsRebootTombstones(t *testing.T) {
 		store.purgeClient(clientID)
 	}
 
-	if len(store.expired) != maxRecoveredCloseResponses {
+	if len(store.expired) != maxTombstones {
 		t.Fatalf("expired stateids = %d, want %d",
-			len(store.expired), maxRecoveredCloseResponses)
+			len(store.expired), maxTombstones)
 	}
-	if len(store.revoked) != maxRecoveredCloseResponses {
+	if len(store.revoked) != maxTombstones {
 		t.Fatalf("revoked clientids = %d, want %d",
-			len(store.revoked), maxRecoveredCloseResponses)
+			len(store.revoked), maxTombstones)
 	}
 	if _, found := store.expired[firstStateID]; found {
 		t.Fatal("oldest expired stateid was not evicted")
 	}
 	if _, found := store.revoked[1]; found {
 		t.Fatal("oldest revoked clientid was not evicted")
-	}
-}
-
-func TestOpenStateStoreRecoveredClose(t *testing.T) {
-	store := newOpenStateStore()
-	fileID := MakeInodeID(InodeTypeFile, 1)
-	var recoveredID StateID
-	binary.BigEndian.PutUint32(recoveredID[0:4], store.epoch+1)
-	recoveredID[11] = 1
-	if !store.canRecover(recoveredID) {
-		t.Fatal("previous-epoch staging stateid was not recoverable")
-	}
-	closed := store.closeRecovered(recoveredID, fileID, 2, 3)
-	if closed.generation != 3 {
-		t.Fatalf("recovered CLOSE generation = %d, want 3",
-			closed.generation)
-	}
-	replayed, replay, status := store.validateClose(
-		recoveredID, 2, fileID, 3,
-	)
-	if status != NFS4_OK || !replay || replayed.id != recoveredID {
-		t.Fatalf("recovered CLOSE replay status = %s, replay = %t",
-			Nfsstat4Name(status), replay)
 	}
 }
 
@@ -5367,9 +5644,22 @@ func closeLocalStagingFiles(t *testing.T, store *LocalStagingStore) {
 	}
 }
 
-func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
-	rootDir := t.TempDir()
-	stagingDir := t.TempDir()
+type restartedStagedWrite struct {
+	rootDir    string
+	stagingDir string
+	conn       net.Conn
+	xid        uint32
+	stateid    [16]byte
+	fh         []byte
+}
+
+func restartWithStagedWrite(
+	t *testing.T,
+	name string,
+	initial []byte,
+) restartedStagedWrite {
+	t.Helper()
+	rootDir, stagingDir := t.TempDir(), t.TempDir()
 	fs := NewLocalTernVFS(rootDir)
 	firstStaging, err := NewLocalStagingStore(stagingDir, nil)
 	if err != nil {
@@ -5384,22 +5674,17 @@ func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
 	xid := uint32(1)
 	clientID := setupClient(t, conn, &xid)
 	stateid, fh := openCreateFile(
-		t, conn, &xid, clientID, "recovered.txt")
-	data := []byte("staged across an nfsd restart")
+		t, conn, &xid, clientID, name)
 	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
 		pw := w.AppendArgarray_Putfh()
 		buf := pw.StartObject().SetData(fh).Finish()
 		pw.Resume(buf)
 		w.Resume(pw.Finish())
 		ww := w.AppendArgarray_Write()
-		sid := ww.Stateid()
-		sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
-		for i := 0; i < 12; i++ {
-			sid.SetOther(i, stateid[4+i])
-		}
+		setStateid(ww.Stateid(), stateid)
 		ww = ww.SetOffset(0)
 		ww = ww.SetStable(fileSync4)
-		ww = ww.SetData(data)
+		ww = ww.SetData(initial)
 		w.Resume(ww.Finish())
 	})
 	expectOK(t, res)
@@ -5423,29 +5708,45 @@ func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 	addr, stopSecond := serveTestServer(t, second)
-	defer stopSecond()
 	conn = dial(t, addr)
-	defer conn.Close()
+	t.Cleanup(func() {
+		conn.Close()
+		stopSecond()
+	})
 
-	closeXID := uint32(100)
+	return restartedStagedWrite{
+		rootDir:    rootDir,
+		stagingDir: stagingDir,
+		conn:       conn,
+		xid:        100,
+		stateid:    stateid,
+		fh:         fh,
+	}
+}
+
+func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
+	data := []byte("staged across an nfsd restart")
+	restarted := restartWithStagedWrite(t, "recovered.txt", data)
 	if status := closeFileWithSeqStatus(
-		t, conn, &closeXID, fh, stateid, 3,
+		t, restarted.conn, &restarted.xid, restarted.fh,
+		restarted.stateid, 3,
 	); status != NFS4_OK {
 		t.Fatalf("recovered CLOSE = %s", Nfsstat4Name(status))
 	}
 	if status := closeFileWithSeqStatus(
-		t, conn, &closeXID, fh, stateid, 3,
+		t, restarted.conn, &restarted.xid, restarted.fh,
+		restarted.stateid, 3,
 	); status != NFS4_OK {
 		t.Fatalf("recovered CLOSE replay = %s", Nfsstat4Name(status))
 	}
-	got, err := os.ReadFile(filepath.Join(rootDir, "recovered.txt"))
+	got, err := os.ReadFile(filepath.Join(restarted.rootDir, "recovered.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(got, data) {
 		t.Fatalf("recovered file data = %q, want %q", got, data)
 	}
-	entries, err := os.ReadDir(stagingDir)
+	entries, err := os.ReadDir(restarted.stagingDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5457,112 +5758,53 @@ func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
 func TestStagedWriteOperationsAfterServerRestart(t *testing.T) {
 	for _, operation := range []string{"write", "read", "setattr-size"} {
 		t.Run(operation, func(t *testing.T) {
-			rootDir := t.TempDir()
-			stagingDir := t.TempDir()
-			fs := NewLocalTernVFS(rootDir)
-			firstStaging, err := NewLocalStagingStore(stagingDir, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			first, err := NewServer(fs, firstStaging, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			addr, stopFirst := serveTestServer(t, first)
-			conn := dial(t, addr)
-			xid := uint32(1)
-			clientID := setupClient(t, conn, &xid)
-			stateid, fh := openCreateFile(
-				t, conn, &xid, clientID, operation+".txt")
 			initial := []byte("before restart")
-			res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-				pw := w.AppendArgarray_Putfh()
-				buf := pw.StartObject().SetData(fh).Finish()
-				pw.Resume(buf)
-				w.Resume(pw.Finish())
-				ww := w.AppendArgarray_Write()
-				sid := ww.Stateid()
-				sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
-				for i := 0; i < 12; i++ {
-					sid.SetOther(i, stateid[4+i])
-				}
-				ww = ww.SetOffset(0)
-				ww = ww.SetStable(fileSync4)
-				ww = ww.SetData(initial)
-				w.Resume(ww.Finish())
-			})
-			expectOK(t, res)
-			conn.Close()
-			stopFirst()
-			closeLocalStagingFiles(t, firstStaging)
-
-			recoveredStaging, err := NewLocalStagingStore(stagingDir, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			second, err := NewServer(fs, recoveredStaging, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			addr, stopSecond := serveTestServer(t, second)
-			defer stopSecond()
-			conn = dial(t, addr)
-			defer conn.Close()
-			xid = 100
+			restarted := restartWithStagedWrite(
+				t, operation+".txt", initial)
 
 			var expected []byte
-			res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-				pw := w.AppendArgarray_Putfh()
-				buf := pw.StartObject().SetData(fh).Finish()
-				pw.Resume(buf)
-				w.Resume(pw.Finish())
-				switch operation {
-				case "write":
-					appended := []byte(" and after")
-					expected = append(append([]byte(nil), initial...), appended...)
-					ww := w.AppendArgarray_Write()
-					sid := ww.Stateid()
-					sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
-					for i := 0; i < 12; i++ {
-						sid.SetOther(i, stateid[4+i])
+			res := sendCompound(
+				t, restarted.conn, restarted.xid,
+				func(w *COMPOUND4argsWriter) {
+					pw := w.AppendArgarray_Putfh()
+					buf := pw.StartObject().SetData(restarted.fh).Finish()
+					pw.Resume(buf)
+					w.Resume(pw.Finish())
+					switch operation {
+					case "write":
+						appended := []byte(" and after")
+						expected = append(append([]byte(nil), initial...), appended...)
+						ww := w.AppendArgarray_Write()
+						setStateid(ww.Stateid(), restarted.stateid)
+						ww = ww.SetOffset(uint64(len(initial)))
+						ww = ww.SetStable(fileSync4)
+						ww = ww.SetData(appended)
+						w.Resume(ww.Finish())
+					case "read":
+						expected = append([]byte(nil), initial...)
+						rw := w.AppendArgarray_Read()
+						setStateid(rw.Stateid(), restarted.stateid)
+						rw.SetOffset(0)
+						rw.SetCount(1024)
+					case "setattr-size":
+						expected = append([]byte(nil), initial[:6]...)
+						saw := w.AppendArgarray_Setattr()
+						setStateid(saw.Stateid(), restarted.stateid)
+						faw := saw.StartObjAttributes()
+						bmW := faw.StartAttrmask()
+						bmW.AppendData(1 << FATTR4_SIZE)
+						buf = bmW.Finish()
+						faw.Resume(buf)
+						attrData := make([]byte, 8)
+						binary.BigEndian.PutUint64(attrData, uint64(len(expected)))
+						alW := faw.StartAttrVals()
+						buf = alW.SetData(attrData).Finish()
+						faw.Resume(buf)
+						saw.Resume(faw.Finish())
+						w.Resume(saw.Finish())
 					}
-					ww = ww.SetOffset(uint64(len(initial)))
-					ww = ww.SetStable(fileSync4)
-					ww = ww.SetData(appended)
-					w.Resume(ww.Finish())
-				case "read":
-					expected = append([]byte(nil), initial...)
-					rw := w.AppendArgarray_Read()
-					sid := rw.Stateid()
-					sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
-					for i := 0; i < 12; i++ {
-						sid.SetOther(i, stateid[4+i])
-					}
-					rw.SetOffset(0)
-					rw.SetCount(1024)
-				case "setattr-size":
-					expected = append([]byte(nil), initial[:6]...)
-					saw := w.AppendArgarray_Setattr()
-					sid := saw.Stateid()
-					sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
-					for i := 0; i < 12; i++ {
-						sid.SetOther(i, stateid[4+i])
-					}
-					faw := saw.StartObjAttributes()
-					bmW := faw.StartAttrmask()
-					bmW.AppendData(1 << FATTR4_SIZE)
-					buf = bmW.Finish()
-					faw.Resume(buf)
-					attrData := make([]byte, 8)
-					binary.BigEndian.PutUint64(attrData, uint64(len(expected)))
-					alW := faw.StartAttrVals()
-					buf = alW.SetData(attrData).Finish()
-					faw.Resume(buf)
-					saw.Resume(faw.Finish())
-					w.Resume(saw.Finish())
-				}
-			})
-			xid++
+				})
+			restarted.xid++
 			iter := expectOK(t, res)
 			nextOp(t, &iter)
 			entry := nextOp(t, &iter)
@@ -5574,8 +5816,11 @@ func TestStagedWriteOperationsAfterServerRestart(t *testing.T) {
 				}
 			}
 
-			closeFile(t, conn, &xid, fh, stateid)
-			got, err := os.ReadFile(filepath.Join(rootDir, operation+".txt"))
+			closeFile(
+				t, restarted.conn, &restarted.xid,
+				restarted.fh, restarted.stateid)
+			got, err := os.ReadFile(
+				filepath.Join(restarted.rootDir, operation+".txt"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -5615,38 +5860,11 @@ func TestSetclientidRebootRemovesStagingFiles(t *testing.T) {
 		t.Fatal("write OPEN did not create staging")
 	}
 
-	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		scw := w.AppendArgarray_Setclientid()
-		clientW := scw.StartClient()
-		for i := 0; i < 8; i++ {
-			clientW.Verifier().SetData(i, byte(i+1))
-		}
-		clientW = clientW.SetId([]byte("test-client"))
-		buf := clientW.Finish()
-		scw.Resume(buf)
-		cbW := scw.StartCallback()
-		cbW.SetCbProgram(0x40000000)
-		locW := cbW.StartCbLocation()
-		buf = locW.StartRNetid().SetData([]byte("tcp")).Finish()
-		locW.Resume(buf)
-		buf = locW.StartRAddr().SetData([]byte("0.0.0.0.0.0")).Finish()
-		locW.Resume(buf)
-		cbW.Resume(locW.Finish())
-		scw.Resume(cbW.Finish())
-		scw.SetCallbackIdent(0)
-		w.Resume(scw.Finish())
-	})
-	xid++
-	iter := expectOK(t, res)
-	entry := nextOp(t, &iter)
-	newClientID := entry.Value().AsSETCLIENTID4resEntry().
-		Value().AsSETCLIENTID4resok().Clientid()
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		cw := w.AppendArgarray_SetclientidConfirm()
-		cw.SetClientid(newClientID)
-	})
-	xid++
-	expectOK(t, res)
+	var rebootVerifier [8]byte
+	for i := range rebootVerifier {
+		rebootVerifier[i] = byte(i + 1)
+	}
+	setupClientWithVerifier(t, conn, &xid, rebootVerifier)
 
 	if staging.Get(fileID) != nil {
 		t.Fatal("client reboot retained staging in memory")
@@ -5679,58 +5897,14 @@ func TestSetclientidReboot(t *testing.T) {
 	clientid1 := setupClient(t, conn, &xid)
 	stateid, fh := openReadFile(t, conn, &xid, clientid1, "file.txt")
 
-	// Second SETCLIENTID with same identity but different verifier (simulating reboot).
-	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		scw := w.AppendArgarray_Setclientid()
-		clientW := scw.StartClient()
-		// Same identity string as setupClient.
-		clientW = clientW.SetId([]byte("test-client"))
-		// Different verifier (setupClient uses default zero verifier).
-		verf := clientW.Verifier()
-		for i := 0; i < 8; i++ {
-			verf.SetData(i, byte(i+1))
-		}
-		buf := clientW.Finish()
-		scw.Resume(buf)
-		cbW := scw.StartCallback()
-		cbW.SetCbProgram(0x40000000)
-		locW := cbW.StartCbLocation()
-		netidW := locW.StartRNetid()
-		buf = netidW.SetData([]byte("tcp")).Finish()
-		locW.Resume(buf)
-		addrW := locW.StartRAddr()
-		buf = addrW.SetData([]byte("0.0.0.0.0.0")).Finish()
-		locW.Resume(buf)
-		buf = locW.Finish()
-		cbW.Resume(buf)
-		buf = cbW.Finish()
-		scw.Resume(buf)
-		scw.SetCallbackIdent(0)
-		buf = scw.Finish()
-		w.Resume(buf)
-	})
-	xid++
-	iter := expectOK(t, res)
-	entry := nextOp(t, &iter)
-	scRes := entry.Value().AsSETCLIENTID4resEntry()
-	if scRes.Disc() != NFS4_OK {
-		t.Fatalf("SETCLIENTID reboot: status = %s", Nfsstat4Name(scRes.Disc()))
+	// Repeat the identity with a different verifier to simulate a reboot.
+	var rebootVerifier [8]byte
+	for i := range rebootVerifier {
+		rebootVerifier[i] = byte(i + 1)
 	}
-	clientid2 := scRes.Value().AsSETCLIENTID4resok().Clientid()
+	setupClientWithVerifier(t, conn, &xid, rebootVerifier)
 
-	// CONFIRM.
-	res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		scw := w.AppendArgarray_SetclientidConfirm()
-		scw.SetClientid(clientid2)
-	})
-	xid++
-	iter = expectOK(t, res)
-	entry = nextOp(t, &iter)
-	if entry.Value().AsSETCLIENTIDCONFIRM4res().Status() != NFS4_OK {
-		t.Fatal("SETCLIENTID_CONFIRM reboot failed")
-	}
-
-	status := closeFileExpectStatus(t, conn, &xid, fh, stateid)
+	status := closeFileWithSeqStatus(t, conn, &xid, fh, stateid, 3)
 	if status != NFS4ERR_EXPIRED {
 		t.Fatalf("CLOSE after client reboot = %s, want NFS4ERR_EXPIRED",
 			Nfsstat4Name(status))

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -22,6 +22,15 @@ import (
 func startTestServer(
 	t *testing.T,
 	dir string,
+) (addr string, cleanup func()) {
+	t.Helper()
+	_, addr, cleanup = startTestServerWithServer(t, dir)
+	return addr, cleanup
+}
+
+func startTestServerWithServer(
+	t *testing.T,
+	dir string,
 ) (srv *Server, addr string, cleanup func()) {
 	t.Helper()
 	fs := NewLocalTernVFS(dir)
@@ -141,7 +150,7 @@ func sendCompound(t *testing.T, conn net.Conn, xid uint32, build func(w *COMPOUN
 
 func TestEmptyCompound(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -172,7 +181,7 @@ func TestEmptyCompound(t *testing.T) {
 
 func TestCompoundOperationLimit(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -325,7 +334,7 @@ func setupClientWithVerifier(
 
 func TestNullRPC(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -339,7 +348,7 @@ func TestNullRPC(t *testing.T) {
 
 func TestProgMismatch(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -376,7 +385,7 @@ func TestProgMismatch(t *testing.T) {
 
 func TestPutrootfhGetattr(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -420,7 +429,7 @@ func TestPutrootfhGetattr(t *testing.T) {
 
 func TestPutpubfh(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -447,7 +456,7 @@ func TestLookupAndRead(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("Hello, NFS!"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -509,7 +518,7 @@ func TestReadWithOffset(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "data.txt"), []byte("0123456789abcdef"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -578,7 +587,7 @@ func TestReadEmptyFile(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "empty.txt"), nil, 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -618,7 +627,7 @@ func TestReaddir(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "bbb.txt"), []byte("BB"), 0644)
 	os.Mkdir(filepath.Join(dir, "subdir"), 0755)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -667,7 +676,7 @@ func TestReaddirEmpty(t *testing.T) {
 	dir := t.TempDir()
 	os.Mkdir(filepath.Join(dir, "empty"), 0755)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -708,7 +717,7 @@ func TestPutfhRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -759,7 +768,7 @@ func TestPutfhRoundTrip(t *testing.T) {
 
 func TestPutfhBadHandle(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -784,7 +793,7 @@ func TestSavefhRestorefh(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0644)
 	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -837,7 +846,7 @@ func TestSavefhRestorefh(t *testing.T) {
 
 func TestRestorefhWithoutSave(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -856,7 +865,7 @@ func TestLookupp(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "sub"), 0755)
 	os.WriteFile(filepath.Join(dir, "root.txt"), []byte("at root"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -905,7 +914,7 @@ func TestReadlink(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "target.txt"), []byte("target"), 0644)
 	os.Symlink("target.txt", filepath.Join(dir, "link.txt"))
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -939,7 +948,7 @@ func TestReadlink(t *testing.T) {
 
 func TestAccess(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1007,7 +1016,7 @@ func TestAccessMasksUnsupportedBitsByType(t *testing.T) {
 			if err := os.Symlink("file", filepath.Join(dir, "link")); err != nil {
 				t.Fatal(err)
 			}
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1045,7 +1054,7 @@ func TestOpenConfirmClose(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1077,7 +1086,7 @@ func TestOpenConfirmClose(t *testing.T) {
 
 func TestSetclientidFlow(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1174,7 +1183,7 @@ func TestClientStoreRecognizesConfirmedClientAfterRestart(t *testing.T) {
 
 func TestSetattr(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1209,7 +1218,7 @@ func TestSetattr(t *testing.T) {
 
 func TestReleaseLockowner(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1237,7 +1246,7 @@ func TestReleaseLockowner(t *testing.T) {
 
 func TestIllegalOp(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1253,7 +1262,7 @@ func TestIllegalOp(t *testing.T) {
 
 func TestUnknownOp(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1288,7 +1297,7 @@ func TestUnknownOp(t *testing.T) {
 
 func TestLookupNonExistent(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1400,7 +1409,7 @@ func TestLongNamesRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1430,7 +1439,7 @@ func TestRenameInvalidNamesRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1473,7 +1482,7 @@ func TestOpenInvalidNamesRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1548,7 +1557,7 @@ func TestEmptyComponentsRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1564,7 +1573,7 @@ func TestEmptyComponentsRejected(t *testing.T) {
 
 func TestLookuppAtRootRejected(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1581,7 +1590,7 @@ func TestLookuppAtRootRejected(t *testing.T) {
 
 func TestSecinfoRequiresExistingName(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -1661,7 +1670,7 @@ func TestCreateInvalidFieldsRejected(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1726,7 +1735,7 @@ func TestCreateTypeAndAttributesValidated(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1779,7 +1788,7 @@ func TestCreateExistingNameRejected(t *testing.T) {
 			if err := test.setup(filepath.Join(dir, "existing")); err != nil {
 				t.Fatal(err)
 			}
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1831,7 +1840,7 @@ func TestOpenCreateAttributesValidated(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1892,7 +1901,7 @@ func TestCreateFromNonDirectoryRejected(t *testing.T) {
 			if err := test.setup(filepath.Join(dir, "parent")); err != nil {
 				t.Fatal(err)
 			}
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -1967,7 +1976,7 @@ func TestCurrentFilehandleTypeValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2054,7 +2063,7 @@ func TestRenameDirectoryFilehandlesValidated(t *testing.T) {
 			if err := os.Symlink("file", filepath.Join(dir, "link")); err != nil {
 				t.Fatal(err)
 			}
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2121,7 +2130,7 @@ func TestOpenFilehandleTypesValidated(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2163,7 +2172,7 @@ func TestOpenFilehandleTypesValidated(t *testing.T) {
 
 func TestNoFilehandle(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2186,7 +2195,7 @@ func TestNoFilehandle(t *testing.T) {
 
 func TestCompoundStopsOnError(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2220,7 +2229,7 @@ func TestSubdirNavigation(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0755)
 	os.WriteFile(filepath.Join(dir, "a", "b", "c", "deep.txt"), []byte("deep content"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2257,7 +2266,7 @@ func TestSubdirNavigation(t *testing.T) {
 
 func TestGetattr_RootType(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2299,7 +2308,7 @@ func TestGetattr_FileSize(t *testing.T) {
 	content := []byte("twelve chars")
 	os.WriteFile(filepath.Join(dir, "sized.txt"), content, 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2343,7 +2352,7 @@ func TestGetattr_Mode(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0644)
 	os.MkdirAll(filepath.Join(dir, "d"), 0755)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2410,7 +2419,7 @@ func TestGetattr_Symlink(t *testing.T) {
 	dir := t.TempDir()
 	os.Symlink("target", filepath.Join(dir, "link"))
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2450,7 +2459,7 @@ func TestMultipleCompoundsOnConnection(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0644)
 	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2493,7 +2502,7 @@ func TestLargeFileRead(t *testing.T) {
 	}
 	os.WriteFile(filepath.Join(dir, "large.bin"), content, 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2532,7 +2541,7 @@ func TestLargeFileRead(t *testing.T) {
 
 func TestGetattr_SupportedAttrs(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2581,7 +2590,7 @@ func TestGetattr_MultipleAttrs(t *testing.T) {
 	content := []byte("test content for multi attr")
 	os.WriteFile(filepath.Join(dir, "multi.txt"), content, 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2655,7 +2664,7 @@ func TestGetattrAttributeMaskValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2700,7 +2709,7 @@ func TestVerifyAttributeMaskValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -2747,7 +2756,7 @@ func finishTestFattr(w Fattr4Writer, mask [2]uint32, values []byte) []byte {
 
 func TestWriteAndRead(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2804,7 +2813,7 @@ func TestWriteAndRead(t *testing.T) {
 
 func TestStagedFileGetattrAndRead(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2904,7 +2913,7 @@ func TestOpenExistingForWriteRejected(t *testing.T) {
 	// Create an existing file.
 	os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("original"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2944,7 +2953,7 @@ func TestOpenExistingForWriteRejected(t *testing.T) {
 
 func TestCreateDirectory(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -2994,7 +3003,7 @@ func TestRemoveFile(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "victim.txt"), []byte("delete me"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3029,7 +3038,7 @@ func TestRename(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "old.txt"), []byte("rename me"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3078,7 +3087,7 @@ func TestRenameToSameNameIsNoOp(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(dir, "same"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3112,7 +3121,7 @@ func TestRenameToSameNameIsNoOp(t *testing.T) {
 
 func TestDelegpurgeNotSupported(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3131,7 +3140,7 @@ func TestLinkNotSupported(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("test"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3157,7 +3166,7 @@ func TestCreateSymlink(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "target.txt"), []byte("target"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3207,7 +3216,7 @@ func TestCreateSymlink(t *testing.T) {
 
 func TestMinorVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3239,7 +3248,7 @@ func TestMinorVersionMismatch(t *testing.T) {
 
 func TestCreateEmptyFile(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3639,7 +3648,7 @@ func TestReaddirPagination(t *testing.T) {
 	}
 	sort.Strings(expected)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3674,7 +3683,7 @@ func TestReaddirCookieverfMismatch(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3740,7 +3749,7 @@ func TestReaddirReservedCookies(t *testing.T) {
 	for _, cookie := range []uint64{1, 2} {
 		t.Run(fmt.Sprintf("cookie_%d", cookie), func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -3766,7 +3775,7 @@ func TestReaddirReservedCookies(t *testing.T) {
 
 func TestReaddirWriteOnlyAttributesRejected(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3793,7 +3802,7 @@ func TestReaddirTooSmall(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3822,7 +3831,7 @@ func TestReaddirNfsDirHidden(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "visible.txt"), []byte("x"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3861,7 +3870,7 @@ func TestReaddirTransientNotVisible(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("x"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3911,7 +3920,7 @@ func TestSetattrTime(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -3975,7 +3984,7 @@ func TestSetattrModeRejected(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4064,7 +4073,7 @@ func TestSetattrValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_, addr, cleanup := startTestServer(t, dir)
+			addr, cleanup := startTestServer(t, dir)
 			defer cleanup()
 			conn := dial(t, addr)
 			defer conn.Close()
@@ -4101,7 +4110,7 @@ func TestSetattrValidation(t *testing.T) {
 
 func TestSetattrSize(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4183,7 +4192,7 @@ func TestSetattrSize(t *testing.T) {
 func TestSetattrSizeRequiresWriteOpen(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4220,7 +4229,7 @@ func TestSetattrSizeRequiresWriteOpen(t *testing.T) {
 
 func TestOpenExclusive4Rejected(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4263,7 +4272,7 @@ func TestOpenClaimPrevious(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4294,48 +4303,6 @@ func TestOpenClaimPrevious(t *testing.T) {
 	}
 }
 
-func TestOpenRflagsRequireConfirm(t *testing.T) {
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
-
-	_, addr, cleanup := startTestServer(t, dir)
-	defer cleanup()
-	conn := dial(t, addr)
-	defer conn.Close()
-
-	xid := uint32(1)
-	clientid := setupClient(t, conn, &xid)
-
-	res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
-		w.AppendArgarray_Putrootfh()
-		ow := w.AppendArgarray_Open()
-		ow.SetSeqid(1)
-		ow.SetShareAccess(OPEN4_SHARE_ACCESS_READ)
-		ow.SetShareDeny(OPEN4_SHARE_DENY_NONE)
-		ownerW := ow.StartOwner()
-		ownerW = ownerW.SetClientid(clientid)
-		ownerW = ownerW.SetOwner([]byte("test-owner"))
-		buf := ownerW.Finish()
-		ow.Resume(buf)
-		ow.SetOpenhow_Default(OPEN4_NOCREATE)
-		cw := ow.SetClaim_Null()
-		buf = cw.SetData([]byte("file.txt")).Finish()
-		ow.Resume(buf)
-		buf = ow.Finish()
-		w.Resume(buf)
-	})
-	xid++
-
-	iter := expectOK(t, res)
-	nextOp(t, &iter) // PUTROOTFH
-	entry := nextOp(t, &iter)
-	openOk := entry.Value().AsOPEN4resEntry().Value().AsOPEN4resok()
-	rflags := openOk.Rflags()
-	if rflags&OPEN4_RESULT_CONFIRM == 0 {
-		t.Fatal("OPEN4_RESULT_CONFIRM should be set")
-	}
-}
-
 func TestOpenConfirmReplay(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(
@@ -4343,7 +4310,7 @@ func TestOpenConfirmReplay(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4376,7 +4343,7 @@ func TestOpenConfirmOldStateidAdvancesSeqid(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4414,7 +4381,7 @@ func TestOpenConfirmOldStateidAdvancesSeqid(t *testing.T) {
 
 func TestCloseReplay(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4453,7 +4420,7 @@ func TestFailedOpenAdvancesOwnerSeqid(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4508,7 +4475,7 @@ func TestOnlyFirstOpenRequiresConfirmation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4555,7 +4522,7 @@ func TestReopenReusesState(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	srv, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4615,22 +4582,6 @@ func TestReopenReusesState(t *testing.T) {
 	); status != NFS4_OK {
 		t.Fatalf("CLOSE status = %s", Nfsstat4Name(status))
 	}
-	srv.opens.mu.Lock()
-	defer srv.opens.mu.Unlock()
-	if len(srv.opens.states) != 0 {
-		t.Fatalf("states after CLOSE = %d, want 0", len(srv.opens.states))
-	}
-	owner := srv.opens.owners[openOwnerKey{
-		clientID: clientID,
-		owner:    "shared-owner",
-	}]
-	if owner == nil {
-		t.Fatal("open owner was removed after CLOSE")
-	}
-	if len(owner.states) != 0 {
-		t.Fatalf("owner states after CLOSE = %d, want 0",
-			len(owner.states))
-	}
 }
 
 func TestReadCloseAfterFileRemoval(t *testing.T) {
@@ -4639,7 +4590,7 @@ func TestReadCloseAfterFileRemoval(t *testing.T) {
 	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	srv, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4656,16 +4607,11 @@ func TestReadCloseAfterFileRemoval(t *testing.T) {
 		t.Fatalf("CLOSE after removal = %s, want NFS4_OK",
 			Nfsstat4Name(status))
 	}
-	srv.opens.mu.Lock()
-	defer srv.opens.mu.Unlock()
-	if len(srv.opens.states) != 0 {
-		t.Fatalf("states after CLOSE = %d, want 0", len(srv.opens.states))
-	}
 }
 
 func TestWriteCloseWithoutStagingExpiresAndDropsState(t *testing.T) {
 	dir := t.TempDir()
-	srv, addr, cleanup := startTestServer(t, dir)
+	srv, addr, cleanup := startTestServerWithServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -4685,143 +4631,83 @@ func TestWriteCloseWithoutStagingExpiresAndDropsState(t *testing.T) {
 		t.Fatalf("CLOSE without staging = %s, want NFS4ERR_EXPIRED",
 			Nfsstat4Name(status))
 	}
-
-	srv.opens.mu.Lock()
-	defer srv.opens.mu.Unlock()
-	if len(srv.opens.states) != 0 {
-		t.Fatalf("states after expired CLOSE = %d, want 0",
-			len(srv.opens.states))
-	}
-	owner := srv.opens.owners[openOwnerKey{
-		clientID: clientID,
-		owner:    "test-owner-lost.txt",
-	}]
-	if owner == nil {
-		t.Fatal("open owner was removed after expired CLOSE")
-	}
-	if len(owner.states) != 0 {
-		t.Fatalf("owner states after expired CLOSE = %d, want 0",
-			len(owner.states))
+	if status := closeFileWithSeqStatus(
+		t, conn, &xid, fh, stateid, 3,
+	); status != NFS4ERR_EXPIRED {
+		t.Fatalf("replayed CLOSE without staging = %s, want NFS4ERR_EXPIRED",
+			Nfsstat4Name(status))
 	}
 }
 
-func TestUnconfirmedOwnerOutOfSequenceOpen(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(
-		filepath.Join(dir, "second.txt"), []byte("data"), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
-	srv, addr, cleanup := startTestServer(t, dir)
-	staging := srv.stagingStore.(*LocalStagingStore)
-	defer cleanup()
-	conn := dial(t, addr)
-	defer conn.Close()
+func TestUnconfirmedOwnerReplacementOpen(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		seq  uint32
+	}{
+		{"in sequence", 2},
+		{"out of sequence", 7},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(
+				filepath.Join(dir, "second.txt"), []byte("data"), 0644,
+			); err != nil {
+				t.Fatal(err)
+			}
+			srv, addr, cleanup := startTestServerWithServer(t, dir)
+			staging := srv.stagingStore.(*LocalStagingStore)
+			defer cleanup()
+			conn := dial(t, addr)
+			defer conn.Close()
 
-	xid := uint32(1)
-	clientID := setupClient(t, conn, &xid)
-	status, first, firstFH, flags := openFileForOwner(
-		t, conn, &xid, clientID, "shared-owner", 1, "first.txt",
-		OPEN4_SHARE_ACCESS_BOTH, true, false,
-	)
-	if status != NFS4_OK || flags&OPEN4_RESULT_CONFIRM == 0 {
-		t.Fatalf("first OPEN status = %s, rflags = %#x",
-			Nfsstat4Name(status), flags)
-	}
-	firstID, ok := fhToInodeID(firstFH)
-	if !ok {
-		t.Fatal("invalid filehandle returned by first OPEN")
-	}
-	if staging.Get(firstID) == nil {
-		t.Fatal("first OPEN did not create staging")
-	}
+			xid := uint32(1)
+			clientID := setupClient(t, conn, &xid)
+			status, first, firstFH, flags := openFileForOwner(
+				t, conn, &xid, clientID, "shared-owner", 1, "first.txt",
+				OPEN4_SHARE_ACCESS_BOTH, true, false,
+			)
+			if status != NFS4_OK || flags&OPEN4_RESULT_CONFIRM == 0 {
+				t.Fatalf("first OPEN status = %s, rflags = %#x",
+					Nfsstat4Name(status), flags)
+			}
+			firstID, ok := fhToInodeID(firstFH)
+			if !ok {
+				t.Fatal("invalid filehandle returned by first OPEN")
+			}
+			if staging.Get(firstID) == nil {
+				t.Fatal("first OPEN did not create staging")
+			}
 
-	status, second, secondFH, flags := openFileForOwner(
-		t, conn, &xid, clientID, "shared-owner", 7, "second.txt",
-		OPEN4_SHARE_ACCESS_READ, false, false,
-	)
-	if status != NFS4_OK {
-		t.Fatalf("out-of-sequence OPEN = %s, want NFS4_OK",
-			Nfsstat4Name(status))
-	}
-	if flags&OPEN4_RESULT_CONFIRM == 0 {
-		t.Fatal("replacement OPEN did not require confirmation")
-	}
-	if staging.Get(firstID) != nil {
-		t.Fatal("replacement OPEN retained abandoned staging")
-	}
-	if status := closeFileWithSeqStatus(
-		t, conn, &xid, firstFH, first, 8,
-	); status != NFS4ERR_BAD_STATEID {
-		t.Fatalf("abandoned stateid CLOSE = %s, want NFS4ERR_BAD_STATEID",
-			Nfsstat4Name(status))
-	}
+			status, second, secondFH, flags := openFileForOwner(
+				t, conn, &xid, clientID, "shared-owner", test.seq, "second.txt",
+				OPEN4_SHARE_ACCESS_READ, false, false,
+			)
+			if status != NFS4_OK {
+				t.Fatalf("replacement OPEN = %s, want NFS4_OK",
+					Nfsstat4Name(status))
+			}
+			if flags&OPEN4_RESULT_CONFIRM == 0 {
+				t.Fatal("replacement OPEN did not require confirmation")
+			}
+			if staging.Get(firstID) != nil {
+				t.Fatal("replacement OPEN retained abandoned staging")
+			}
+			nextSeq := test.seq + 1
+			if status := closeFileWithSeqStatus(
+				t, conn, &xid, firstFH, first, nextSeq,
+			); status != NFS4ERR_BAD_STATEID {
+				t.Fatalf("abandoned stateid CLOSE = %s, want NFS4ERR_BAD_STATEID",
+					Nfsstat4Name(status))
+			}
 
-	second = confirmOpenState(t, conn, &xid, secondFH, 8, second)
-	if status := closeFileWithSeqStatus(
-		t, conn, &xid, secondFH, second, 9,
-	); status != NFS4_OK {
-		t.Fatalf("replacement CLOSE = %s", Nfsstat4Name(status))
-	}
-}
-
-func TestUnconfirmedOwnerInSequenceOpen(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(
-		filepath.Join(dir, "second.txt"), []byte("data"), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
-	srv, addr, cleanup := startTestServer(t, dir)
-	staging := srv.stagingStore.(*LocalStagingStore)
-	defer cleanup()
-	conn := dial(t, addr)
-	defer conn.Close()
-
-	xid := uint32(1)
-	clientID := setupClient(t, conn, &xid)
-	status, first, firstFH, flags := openFileForOwner(
-		t, conn, &xid, clientID, "shared-owner", 1, "first.txt",
-		OPEN4_SHARE_ACCESS_BOTH, true, false,
-	)
-	if status != NFS4_OK || flags&OPEN4_RESULT_CONFIRM == 0 {
-		t.Fatalf("first OPEN status = %s, rflags = %#x",
-			Nfsstat4Name(status), flags)
-	}
-	firstID, ok := fhToInodeID(firstFH)
-	if !ok {
-		t.Fatal("invalid filehandle returned by first OPEN")
-	}
-	if staging.Get(firstID) == nil {
-		t.Fatal("first OPEN did not create staging")
-	}
-
-	status, second, secondFH, flags := openFileForOwner(
-		t, conn, &xid, clientID, "shared-owner", 2, "second.txt",
-		OPEN4_SHARE_ACCESS_READ, false, false,
-	)
-	if status != NFS4_OK {
-		t.Fatalf("in-sequence OPEN = %s, want NFS4_OK",
-			Nfsstat4Name(status))
-	}
-	if flags&OPEN4_RESULT_CONFIRM == 0 {
-		t.Fatal("replacement OPEN did not require confirmation")
-	}
-	if staging.Get(firstID) != nil {
-		t.Fatal("replacement OPEN retained abandoned staging")
-	}
-	if status := closeFileWithSeqStatus(
-		t, conn, &xid, firstFH, first, 3,
-	); status != NFS4ERR_BAD_STATEID {
-		t.Fatalf("abandoned stateid CLOSE = %s, want NFS4ERR_BAD_STATEID",
-			Nfsstat4Name(status))
-	}
-
-	second = confirmOpenState(t, conn, &xid, secondFH, 3, second)
-	if status := closeFileWithSeqStatus(
-		t, conn, &xid, secondFH, second, 4,
-	); status != NFS4_OK {
-		t.Fatalf("replacement CLOSE = %s", Nfsstat4Name(status))
+			second = confirmOpenState(
+				t, conn, &xid, secondFH, nextSeq, second)
+			if status := closeFileWithSeqStatus(
+				t, conn, &xid, secondFH, second, nextSeq+1,
+			); status != NFS4_OK {
+				t.Fatalf("replacement CLOSE = %s", Nfsstat4Name(status))
+			}
+		})
 	}
 }
 
@@ -5255,7 +5141,7 @@ func TestCloseUnknownStateid(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	srv, addr, cleanup := startTestServer(t, dir)
+	srv, addr, cleanup := startTestServerWithServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5280,7 +5166,7 @@ func TestCloseUnknownStateid(t *testing.T) {
 
 func TestWriteBadStateid(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5326,7 +5212,7 @@ func TestWriteBadStateid(t *testing.T) {
 // fallback — may legitimately omit a real stateid on WRITE.
 func TestWriteSpecialStateid(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5372,7 +5258,7 @@ func TestWriteSpecialStateid(t *testing.T) {
 // nfs4lib.setattr default stateid is the anonymous one.
 func TestSetattrSizeSpecialStateid(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5426,7 +5312,7 @@ func TestSetattrSizeSpecialStateid(t *testing.T) {
 
 func TestCommitVerifier(t *testing.T) {
 	dir := t.TempDir()
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5556,7 +5442,7 @@ func TestLockNotSupported(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data"), 0644)
 
-	_, addr, cleanup := startTestServer(t, dir)
+	addr, cleanup := startTestServer(t, dir)
 	defer cleanup()
 	conn := dial(t, addr)
 	defer conn.Close()
@@ -5600,19 +5486,19 @@ func TestOpenOwnerSeqidWrapsToOne(t *testing.T) {
 	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 1, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
-	state, status := store.addOpen(
+	state, status := addOpenForTest(store,
 		owner, ^uint32(0), fileID, false, StateID{},
 	)
 	if status != NFS4_OK {
 		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
 	}
-	if _, status = store.confirm(
+	if _, status = confirmOpenForTest(store,
 		state.id, 1, fileID, 1,
 	); status != NFS4_OK {
 		t.Fatalf("OPEN_CONFIRM seqid 1 = %s, want NFS4_OK",
 			Nfsstat4Name(status))
 	}
-	if _, status = store.confirm(
+	if _, status = confirmOpenForTest(store,
 		state.id, 1, fileID, 0,
 	); status != NFS4ERR_BAD_SEQID {
 		t.Fatalf("OPEN_CONFIRM seqid 0 = %s, want NFS4ERR_BAD_SEQID",
@@ -5626,7 +5512,7 @@ func TestOpenStateStoreCloseChecksSeqidBeforeStateid(t *testing.T) {
 	owner := openOwnerKey{clientID: 7, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
 	state := addConfirmedOpen(t, store, owner, fileID)
-	if _, _, status := store.validateClose(
+	if _, _, status := validateCloseForTest(store,
 		state.id, 1, fileID, 50,
 	); status != NFS4ERR_BAD_SEQID {
 		t.Fatalf("CLOSE error priority status = %s, want NFS4ERR_BAD_SEQID",
@@ -5660,96 +5546,28 @@ func TestOpenStateStoreLookupClassifiesStateids(t *testing.T) {
 	}
 }
 
-func TestOpenStateStoreReplay(t *testing.T) {
-	store := newOpenStateStore()
-	defer assertOpenStateIndex(t, store)
-	fileID := MakeInodeID(InodeTypeFile, 1)
-	owner := openOwnerKey{clientID: 1, owner: "first"}
-	if _, replay, status := store.beginOpen(owner, 4); status != NFS4_OK || replay {
-		t.Fatalf("initial OPEN status = %s, replay = %t",
-			Nfsstat4Name(status), replay)
-	}
-	state, status := store.addOpen(
-		owner, 4, fileID, true, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
-	}
-	replayed, replay, status := store.beginOpen(owner, 4)
-	if status != NFS4_OK || !replay || replayed.id != state.id {
-		t.Fatalf("OPEN replay status = %s, replay = %t",
-			Nfsstat4Name(status), replay)
-	}
-	if _, status = store.confirm(state.id, 1, fileID, 5); status != NFS4_OK {
-		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
-	}
-	if _, replay, status = store.beginOpen(owner, 4); status != NFS4ERR_BAD_SEQID {
-		t.Fatalf("old OPEN seqid status = %s, replay = %t",
-			Nfsstat4Name(status), replay)
-	}
-	secondOwner := openOwnerKey{clientID: 1, owner: "second"}
-	second, status := store.addOpen(
-		secondOwner, 1, fileID, false, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatalf("second OPEN status = %s", Nfsstat4Name(status))
-	}
-	if second.id == state.id {
-		t.Fatalf("second owner replayed first owner stateid %x", state.id)
-	}
-	replayed, replay, status = store.beginOpen(secondOwner, 1)
-	if status != NFS4_OK || !replay || replayed.id != second.id {
-		t.Fatalf("second owner replay status = %s, replay = %t, stateid = %x",
-			Nfsstat4Name(status), replay, replayed.id)
-	}
-}
-
-func TestOpenStateStoreNonExemptCloseErrorAdvancesSeqid(t *testing.T) {
-	store := newOpenStateStore()
-	defer assertOpenStateIndex(t, store)
-	owner := openOwnerKey{clientID: 1, owner: "owner"}
-	fileID := MakeInodeID(InodeTypeFile, 1)
-	state := addConfirmedOpen(t, store, owner, fileID)
-	if _, _, status := store.validateClose(
-		state.id, 1, fileID, 3,
-	); status != NFS4ERR_OLD_STATEID {
-		t.Fatalf("old CLOSE stateid = %s, want NFS4ERR_OLD_STATEID",
-			Nfsstat4Name(status))
-	}
-	if _, _, status := store.validateClose(
-		state.id, 2, fileID, 3,
-	); status != NFS4ERR_BAD_SEQID {
-		t.Fatalf("reused CLOSE seqid = %s, want NFS4ERR_BAD_SEQID",
-			Nfsstat4Name(status))
-	}
-	if _, status := store.close(state.id, 4); status != NFS4_OK {
-		t.Fatalf("advanced CLOSE = %s, want NFS4_OK",
-			Nfsstat4Name(status))
-	}
-}
-
 func TestOpenStateStoreExemptErrorDoesNotAdvance(t *testing.T) {
 	store := newOpenStateStore()
 	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 1, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
-	state, status := store.addOpen(
+	state, status := addOpenForTest(store,
 		owner, 1, fileID, false, StateID{})
 	if status != NFS4_OK {
 		t.Fatal(Nfsstat4Name(status))
 	}
-	if _, status = store.confirm(
+	if _, status = confirmOpenForTest(store,
 		state.id, 2, fileID, 50,
 	); status != NFS4ERR_BAD_SEQID {
 		t.Fatalf("OPEN_CONFIRM error priority = %s, want NFS4ERR_BAD_SEQID",
 			Nfsstat4Name(status))
 	}
-	if _, status = store.confirm(
+	if _, status = confirmOpenForTest(store,
 		state.id, 2, fileID, 2,
 	); status != NFS4ERR_BAD_STATEID {
 		t.Fatalf("bad OPEN_CONFIRM stateid = %s", Nfsstat4Name(status))
 	}
-	if _, status = store.confirm(
+	if _, status = confirmOpenForTest(store,
 		state.id, 1, fileID, 2,
 	); status != NFS4_OK {
 		t.Fatalf("OPEN_CONFIRM after exempt error = %s",
@@ -5762,17 +5580,17 @@ func TestOpenStateStoreDisposesClosedStateAndBoundsOwnerReplay(t *testing.T) {
 	defer assertOpenStateIndex(t, store)
 	owner := openOwnerKey{clientID: 1, owner: "owner"}
 	fileID := MakeInodeID(InodeTypeFile, 1)
-	state, status := store.addOpen(
+	state, status := addOpenForTest(store,
 		owner, 1, fileID, false, StateID{})
 	if status != NFS4_OK {
 		t.Fatal(Nfsstat4Name(status))
 	}
-	if _, status = store.confirm(
+	if _, status = confirmOpenForTest(store,
 		state.id, 1, fileID, 2,
 	); status != NFS4_OK {
 		t.Fatal(Nfsstat4Name(status))
 	}
-	if _, status = store.close(state.id, 3); status != NFS4_OK {
+	if _, status = closeOpenForTest(store, state.id, 3); status != NFS4_OK {
 		t.Fatal(Nfsstat4Name(status))
 	}
 	if len(store.states) != 0 {
@@ -5784,7 +5602,7 @@ func TestOpenStateStoreDisposesClosedStateAndBoundsOwnerReplay(t *testing.T) {
 	}
 
 	secondFileID := MakeInodeID(InodeTypeFile, 2)
-	if _, status = store.addOpen(
+	if _, status = addOpenForTest(store,
 		owner, 4, secondFileID, false, StateID{},
 	); status != NFS4_OK {
 		t.Fatal(Nfsstat4Name(status))
@@ -5796,20 +5614,26 @@ func TestOpenStateStoreDisposesClosedStateAndBoundsOwnerReplay(t *testing.T) {
 	}
 }
 
-func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
+func TestOpenStateStoreKeepsOtherOwnersUntilClientPurge(t *testing.T) {
 	store := newOpenStateStore()
 	defer assertOpenStateIndex(t, store)
 	clientID := uint64(1)
 	var states []openState
-	for i, name := range []string{"user-a", "user-b"} {
+	for i, test := range []struct {
+		owner string
+		write bool
+	}{
+		{"reader", false},
+		{"writer", true},
+	} {
 		fileID := MakeInodeID(InodeTypeFile, uint64(i+1))
-		state, status := store.addOpen(
-			openOwnerKey{clientID: clientID, owner: name},
-			1, fileID, false, StateID{})
+		state, status := addOpenForTest(store,
+			openOwnerKey{clientID: clientID, owner: test.owner},
+			1, fileID, test.write, StateID{})
 		if status != NFS4_OK {
 			t.Fatal(Nfsstat4Name(status))
 		}
-		if _, status = store.confirm(
+		if _, status = confirmOpenForTest(store,
 			state.id, 1, fileID, 2,
 		); status != NFS4_OK {
 			t.Fatal(Nfsstat4Name(status))
@@ -5817,7 +5641,7 @@ func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
 		states = append(states, state)
 	}
 
-	if _, status := store.close(states[0].id, 3); status != NFS4_OK {
+	if _, status := closeOpenForTest(store, states[0].id, 3); status != NFS4_OK {
 		t.Fatalf("first owner CLOSE = %s", Nfsstat4Name(status))
 	}
 	if len(store.states) != 1 {
@@ -5830,48 +5654,14 @@ func TestOpenStateStoreKeepsAllClientOwnersUntilCloseOrReboot(t *testing.T) {
 			Nfsstat4Name(status))
 	}
 
-	store.purgeClient(clientID)
+	fileIDs := store.purgeClient(clientID)
+	if len(fileIDs) != 1 || fileIDs[0] != states[1].fileID {
+		t.Fatalf("purged staging file IDs = %v, want [%v]",
+			fileIDs, states[1].fileID)
+	}
 	if len(store.states) != 0 || len(store.owners) != 0 {
 		t.Fatalf("reboot retained states=%d owners=%d",
 			len(store.states), len(store.owners))
-	}
-}
-
-func TestPurgeClientReturnsOnlyWriteFiles(t *testing.T) {
-	store := newOpenStateStore()
-	defer assertOpenStateIndex(t, store)
-	clientID := uint64(1)
-	readID := MakeInodeID(InodeTypeFile, 1)
-	writeID := MakeInodeID(InodeTypeFile, 2)
-	readState, status := store.addOpen(
-		openOwnerKey{clientID: clientID, owner: "read"},
-		1, readID, false, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatal(Nfsstat4Name(status))
-	}
-	if _, status = store.confirm(
-		readState.id, 1, readID, 2,
-	); status != NFS4_OK {
-		t.Fatal(Nfsstat4Name(status))
-	}
-	writeState, status := store.addOpen(
-		openOwnerKey{clientID: clientID, owner: "write"},
-		1, writeID, true, StateID{},
-	)
-	if status != NFS4_OK {
-		t.Fatal(Nfsstat4Name(status))
-	}
-	if _, status = store.confirm(
-		writeState.id, 1, writeID, 2,
-	); status != NFS4_OK {
-		t.Fatal(Nfsstat4Name(status))
-	}
-
-	fileIDs := store.purgeClient(clientID)
-	if len(fileIDs) != 1 || fileIDs[0] != writeID {
-		t.Fatalf("purged staging file IDs = %v, want [%v]",
-			fileIDs, writeID)
 	}
 }
 
@@ -5882,7 +5672,7 @@ func TestOpenStateStoreBoundsRebootTombstones(t *testing.T) {
 	var firstStateID StateID
 	for i := 0; i <= maxTombstones; i++ {
 		clientID := uint64(i + 1)
-		state, status := store.addOpen(
+		state, status := addOpenForTest(store,
 			openOwnerKey{clientID: clientID, owner: "owner"},
 			1, fileID, false, StateID{})
 		if status != NFS4_OK {
@@ -6047,107 +5837,88 @@ func restartWithStagedWrite(
 	}
 }
 
-func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
-	data := []byte("staged across an nfsd restart")
-	restarted := restartWithStagedWrite(t, "recovered.txt", data)
-	status, first := closeFileWithSeqResult(
-		t, restarted.conn, &restarted.xid, restarted.fh,
-		restarted.stateid, 3,
-	)
-	if status != NFS4_OK {
-		t.Fatalf("recovered CLOSE = %s", Nfsstat4Name(status))
-	}
-	status, replay := closeFileWithSeqResult(
-		t, restarted.conn, &restarted.xid, restarted.fh,
-		restarted.stateid, 3,
-	)
-	if status != NFS4_OK {
-		t.Fatalf("recovered CLOSE replay = %s", Nfsstat4Name(status))
-	}
-	if replay != first {
-		t.Fatalf("recovered CLOSE replay stateid = %x, want %x",
-			replay, first)
-	}
-	got, err := os.ReadFile(filepath.Join(restarted.rootDir, "recovered.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, data) {
-		t.Fatalf("recovered file data = %q, want %q", got, data)
-	}
-	entries, err := os.ReadDir(restarted.stagingDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(entries) != 0 {
-		t.Fatalf("recovered CLOSE retained staging files: %v", entries)
-	}
-}
-
 func TestStagedWriteOperationsAfterServerRestart(t *testing.T) {
-	for _, operation := range []string{"write", "read", "setattr-size"} {
+	for _, operation := range []string{"close", "write", "read", "setattr-size"} {
 		t.Run(operation, func(t *testing.T) {
 			initial := []byte("before restart")
 			restarted := restartWithStagedWrite(
 				t, operation+".txt", initial)
 
-			var expected []byte
-			res := sendCompound(
-				t, restarted.conn, restarted.xid,
-				func(w *COMPOUND4argsWriter) {
-					pw := w.AppendArgarray_Putfh()
-					buf := pw.StartObject().SetData(restarted.fh).Finish()
-					pw.Resume(buf)
-					w.Resume(pw.Finish())
-					switch operation {
-					case "write":
-						appended := []byte(" and after")
-						expected = append(append([]byte(nil), initial...), appended...)
-						ww := w.AppendArgarray_Write()
-						setStateid(ww.Stateid(), restarted.stateid)
-						ww = ww.SetOffset(uint64(len(initial)))
-						ww = ww.SetStable(fileSync4)
-						ww = ww.SetData(appended)
-						w.Resume(ww.Finish())
-					case "read":
-						expected = append([]byte(nil), initial...)
-						rw := w.AppendArgarray_Read()
-						setStateid(rw.Stateid(), restarted.stateid)
-						rw.SetOffset(0)
-						rw.SetCount(1024)
-					case "setattr-size":
-						expected = append([]byte(nil), initial[:6]...)
-						saw := w.AppendArgarray_Setattr()
-						setStateid(saw.Stateid(), restarted.stateid)
-						faw := saw.StartObjAttributes()
-						bmW := faw.StartAttrmask()
-						bmW.AppendData(1 << FATTR4_SIZE)
-						buf = bmW.Finish()
-						faw.Resume(buf)
-						attrData := make([]byte, 8)
-						binary.BigEndian.PutUint64(attrData, uint64(len(expected)))
-						alW := faw.StartAttrVals()
-						buf = alW.SetData(attrData).Finish()
-						faw.Resume(buf)
-						saw.Resume(faw.Finish())
-						w.Resume(saw.Finish())
+			expected := append([]byte(nil), initial...)
+			if operation != "close" {
+				res := sendCompound(
+					t, restarted.conn, restarted.xid,
+					func(w *COMPOUND4argsWriter) {
+						pw := w.AppendArgarray_Putfh()
+						buf := pw.StartObject().SetData(restarted.fh).Finish()
+						pw.Resume(buf)
+						w.Resume(pw.Finish())
+						switch operation {
+						case "write":
+							appended := []byte(" and after")
+							expected = append(expected, appended...)
+							ww := w.AppendArgarray_Write()
+							setStateid(ww.Stateid(), restarted.stateid)
+							ww = ww.SetOffset(uint64(len(initial)))
+							ww = ww.SetStable(fileSync4)
+							ww = ww.SetData(appended)
+							w.Resume(ww.Finish())
+						case "read":
+							rw := w.AppendArgarray_Read()
+							setStateid(rw.Stateid(), restarted.stateid)
+							rw.SetOffset(0)
+							rw.SetCount(1024)
+						case "setattr-size":
+							expected = expected[:6]
+							saw := w.AppendArgarray_Setattr()
+							setStateid(saw.Stateid(), restarted.stateid)
+							faw := saw.StartObjAttributes()
+							bmW := faw.StartAttrmask()
+							bmW.AppendData(1 << FATTR4_SIZE)
+							buf = bmW.Finish()
+							faw.Resume(buf)
+							attrData := make([]byte, 8)
+							binary.BigEndian.PutUint64(
+								attrData, uint64(len(expected)))
+							alW := faw.StartAttrVals()
+							buf = alW.SetData(attrData).Finish()
+							faw.Resume(buf)
+							saw.Resume(faw.Finish())
+							w.Resume(saw.Finish())
+						}
+					})
+				restarted.xid++
+				iter := expectOK(t, res)
+				nextOp(t, &iter)
+				entry := nextOp(t, &iter)
+				if operation == "read" {
+					got := entry.Value().AsREAD4resEntry().
+						Value().AsREAD4resok().Data()
+					if !bytes.Equal(got, expected) {
+						t.Fatalf("recovered READ = %q, want %q", got, expected)
 					}
-				})
-			restarted.xid++
-			iter := expectOK(t, res)
-			nextOp(t, &iter)
-			entry := nextOp(t, &iter)
-			if operation == "read" {
-				got := entry.Value().AsREAD4resEntry().
-					Value().AsREAD4resok().Data()
-				if !bytes.Equal(got, expected) {
-					t.Fatalf("recovered READ = %q, want %q", got, expected)
 				}
 			}
 
-			closeFile(
-				t, restarted.conn, &restarted.xid,
-				restarted.fh, restarted.stateid)
+			status, first := closeFileWithSeqResult(
+				t, restarted.conn, &restarted.xid, restarted.fh,
+				restarted.stateid, 3)
+			if status != NFS4_OK {
+				t.Fatalf("recovered CLOSE = %s", Nfsstat4Name(status))
+			}
+			if operation == "close" {
+				status, replay := closeFileWithSeqResult(
+					t, restarted.conn, &restarted.xid, restarted.fh,
+					restarted.stateid, 3)
+				if status != NFS4_OK {
+					t.Fatalf("recovered CLOSE replay = %s",
+						Nfsstat4Name(status))
+				}
+				if replay != first {
+					t.Fatalf("recovered CLOSE replay stateid = %x, want %x",
+						replay, first)
+				}
+			}
 			got, err := os.ReadFile(
 				filepath.Join(restarted.rootDir, operation+".txt"))
 			if err != nil {
@@ -6155,6 +5926,13 @@ func TestStagedWriteOperationsAfterServerRestart(t *testing.T) {
 			}
 			if !bytes.Equal(got, expected) {
 				t.Fatalf("recovered file data = %q, want %q", got, expected)
+			}
+			entries, err := os.ReadDir(restarted.stagingDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("recovered CLOSE retained staging files: %v", entries)
 			}
 		})
 	}
@@ -6209,33 +5987,6 @@ func TestSetclientidRebootRemovesStagingFiles(t *testing.T) {
 		t, conn, &xid, fh, stateid, 3,
 	); status != NFS4ERR_EXPIRED {
 		t.Fatalf("CLOSE after reboot = %s, want NFS4ERR_EXPIRED",
-			Nfsstat4Name(status))
-	}
-}
-
-func TestSetclientidReboot(t *testing.T) {
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0644)
-	_, addr, cleanup := startTestServer(t, dir)
-	defer cleanup()
-	conn := dial(t, addr)
-	defer conn.Close()
-
-	// First SETCLIENTID + CONFIRM.
-	xid := uint32(1)
-	clientid1 := setupClient(t, conn, &xid)
-	stateid, fh := openReadFile(t, conn, &xid, clientid1, "file.txt")
-
-	// Repeat the identity with a different verifier to simulate a reboot.
-	var rebootVerifier [8]byte
-	for i := range rebootVerifier {
-		rebootVerifier[i] = byte(i + 1)
-	}
-	setupClientWithVerifier(t, conn, &xid, rebootVerifier)
-
-	status := closeFileWithSeqStatus(t, conn, &xid, fh, stateid, 3)
-	if status != NFS4ERR_EXPIRED {
-		t.Fatalf("CLOSE after client reboot = %s, want NFS4ERR_EXPIRED",
 			Nfsstat4Name(status))
 	}
 }

--- a/go/nfsd/nfsd_test.go
+++ b/go/nfsd/nfsd_test.go
@@ -1089,6 +1089,29 @@ func TestSetclientidFlow(t *testing.T) {
 	}
 }
 
+func TestClientStoreRecognizesConfirmedClientAfterRestart(t *testing.T) {
+	fs := NewLocalTernVFS(t.TempDir())
+	first, err := NewClientStore(fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientID, err := first.SetClientID([8]byte{}, []byte("test-client"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.ConfirmClientID(clientID); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := NewClientStore(fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.IsConfirmed(clientID) {
+		t.Fatal("confirmed client was stale after ClientStore restart")
+	}
+}
+
 func TestSetattr(t *testing.T) {
 	dir := t.TempDir()
 	addr, cleanup := startTestServer(t, dir)
@@ -5288,6 +5311,48 @@ func TestOpenStateStoreRecoveredClose(t *testing.T) {
 	}
 }
 
+func TestRecoveredCloseOperationsAreStateidScoped(t *testing.T) {
+	store := newOpenStateStore()
+	var firstID, secondID StateID
+	binary.BigEndian.PutUint32(firstID[0:4], store.epoch+1)
+	binary.BigEndian.PutUint32(secondID[0:4], store.epoch+1)
+	firstID[11] = 1
+	secondID[11] = 2
+
+	first, _, _, status := store.startRecoveredClose(
+		firstID, MakeInodeID(InodeTypeFile, 1), 2, 3)
+	if status != NFS4_OK {
+		t.Fatalf("first recovered CLOSE = %s", Nfsstat4Name(status))
+	}
+
+	attempting := make(chan struct{})
+	started := make(chan *recoveredCloseOperation, 1)
+	go func() {
+		close(attempting)
+		second, _, _, status := store.startRecoveredClose(
+			secondID, MakeInodeID(InodeTypeFile, 2), 2, 3)
+		if status != NFS4_OK {
+			started <- nil
+			return
+		}
+		started <- second
+	}()
+	<-attempting
+
+	var second *recoveredCloseOperation
+	select {
+	case second = <-started:
+		if second == nil {
+			t.Fatal("second recovered CLOSE failed")
+		}
+	case <-time.After(time.Second):
+		first.finish(NFS4_OK)
+		t.Fatal("different recovered stateids were serialized")
+	}
+	first.finish(NFS4_OK)
+	second.finish(NFS4_OK)
+}
+
 func closeLocalStagingFiles(t *testing.T, store *LocalStagingStore) {
 	t.Helper()
 	store.mu.Lock()
@@ -5386,6 +5451,138 @@ func TestStagedWriteCloseAfterServerRestart(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("recovered CLOSE retained staging files: %v", entries)
+	}
+}
+
+func TestStagedWriteOperationsAfterServerRestart(t *testing.T) {
+	for _, operation := range []string{"write", "read", "setattr-size"} {
+		t.Run(operation, func(t *testing.T) {
+			rootDir := t.TempDir()
+			stagingDir := t.TempDir()
+			fs := NewLocalTernVFS(rootDir)
+			firstStaging, err := NewLocalStagingStore(stagingDir, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			first, err := NewServer(fs, firstStaging, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr, stopFirst := serveTestServer(t, first)
+			conn := dial(t, addr)
+			xid := uint32(1)
+			clientID := setupClient(t, conn, &xid)
+			stateid, fh := openCreateFile(
+				t, conn, &xid, clientID, operation+".txt")
+			initial := []byte("before restart")
+			res := sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+				pw := w.AppendArgarray_Putfh()
+				buf := pw.StartObject().SetData(fh).Finish()
+				pw.Resume(buf)
+				w.Resume(pw.Finish())
+				ww := w.AppendArgarray_Write()
+				sid := ww.Stateid()
+				sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
+				for i := 0; i < 12; i++ {
+					sid.SetOther(i, stateid[4+i])
+				}
+				ww = ww.SetOffset(0)
+				ww = ww.SetStable(fileSync4)
+				ww = ww.SetData(initial)
+				w.Resume(ww.Finish())
+			})
+			expectOK(t, res)
+			conn.Close()
+			stopFirst()
+			closeLocalStagingFiles(t, firstStaging)
+
+			recoveredStaging, err := NewLocalStagingStore(stagingDir, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := NewServer(fs, recoveredStaging, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr, stopSecond := serveTestServer(t, second)
+			defer stopSecond()
+			conn = dial(t, addr)
+			defer conn.Close()
+			xid = 100
+
+			var expected []byte
+			res = sendCompound(t, conn, xid, func(w *COMPOUND4argsWriter) {
+				pw := w.AppendArgarray_Putfh()
+				buf := pw.StartObject().SetData(fh).Finish()
+				pw.Resume(buf)
+				w.Resume(pw.Finish())
+				switch operation {
+				case "write":
+					appended := []byte(" and after")
+					expected = append(append([]byte(nil), initial...), appended...)
+					ww := w.AppendArgarray_Write()
+					sid := ww.Stateid()
+					sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
+					for i := 0; i < 12; i++ {
+						sid.SetOther(i, stateid[4+i])
+					}
+					ww = ww.SetOffset(uint64(len(initial)))
+					ww = ww.SetStable(fileSync4)
+					ww = ww.SetData(appended)
+					w.Resume(ww.Finish())
+				case "read":
+					expected = append([]byte(nil), initial...)
+					rw := w.AppendArgarray_Read()
+					sid := rw.Stateid()
+					sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
+					for i := 0; i < 12; i++ {
+						sid.SetOther(i, stateid[4+i])
+					}
+					rw.SetOffset(0)
+					rw.SetCount(1024)
+				case "setattr-size":
+					expected = append([]byte(nil), initial[:6]...)
+					saw := w.AppendArgarray_Setattr()
+					sid := saw.Stateid()
+					sid.SetSeqid(binary.BigEndian.Uint32(stateid[:4]))
+					for i := 0; i < 12; i++ {
+						sid.SetOther(i, stateid[4+i])
+					}
+					faw := saw.StartObjAttributes()
+					bmW := faw.StartAttrmask()
+					bmW.AppendData(1 << FATTR4_SIZE)
+					buf = bmW.Finish()
+					faw.Resume(buf)
+					attrData := make([]byte, 8)
+					binary.BigEndian.PutUint64(attrData, uint64(len(expected)))
+					alW := faw.StartAttrVals()
+					buf = alW.SetData(attrData).Finish()
+					faw.Resume(buf)
+					saw.Resume(faw.Finish())
+					w.Resume(saw.Finish())
+				}
+			})
+			xid++
+			iter := expectOK(t, res)
+			nextOp(t, &iter)
+			entry := nextOp(t, &iter)
+			if operation == "read" {
+				got := entry.Value().AsREAD4resEntry().
+					Value().AsREAD4resok().Data()
+				if !bytes.Equal(got, expected) {
+					t.Fatalf("recovered READ = %q, want %q", got, expected)
+				}
+			}
+
+			closeFile(t, conn, &xid, fh, stateid)
+			got, err := os.ReadFile(filepath.Join(rootDir, operation+".txt"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, expected) {
+				t.Fatalf("recovered file data = %q, want %q", got, expected)
+			}
+		})
 	}
 }
 

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -1,0 +1,332 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"sync"
+)
+
+type openOwnerKey struct {
+	clientID uint64
+	owner    string
+}
+
+type openState struct {
+	id                   StateID
+	fileID               InodeID
+	owner                openOwnerKey
+	write                bool
+	generation           uint32
+	confirmed            bool
+	closed               bool
+	closeSeq             uint32
+	closeInputGeneration uint32
+}
+
+type openOwnerState struct {
+	nextSeq     uint32
+	initialized bool
+	lastOpenSeq uint32
+	lastOpenID  StateID
+}
+
+type openStateStore struct {
+	mu      sync.Mutex
+	epoch   uint32
+	nextID  uint64
+	states  map[StateID]*openState
+	owners  map[openOwnerKey]*openOwnerState
+	expired map[StateID]bool
+}
+
+func newOpenStateStore() *openStateStore {
+	var epochBytes [4]byte
+	for {
+		if _, err := rand.Read(epochBytes[:]); err != nil {
+			panic("generate NFS open-state epoch: " + err.Error())
+		}
+		epoch := binary.BigEndian.Uint32(epochBytes[:])
+		if epoch > 1 {
+			return &openStateStore{
+				epoch:   epoch,
+				states:  make(map[StateID]*openState),
+				owners:  make(map[openOwnerKey]*openOwnerState),
+				expired: make(map[StateID]bool),
+			}
+		}
+	}
+}
+
+func (os *openStateStore) newStateIDLocked() StateID {
+	os.nextID++
+	var id StateID
+	binary.BigEndian.PutUint32(id[0:4], os.epoch)
+	binary.BigEndian.PutUint64(id[4:12], os.nextID)
+	return id
+}
+
+func (os *openStateStore) newStateID() StateID {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	return os.newStateIDLocked()
+}
+
+func (os *openStateStore) beginOpen(
+	owner openOwnerKey,
+	seq uint32,
+) (openState, bool, uint32) {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	state := os.owners[owner]
+	if state == nil || !state.initialized || seq == state.nextSeq {
+		return openState{}, false, NFS4_OK
+	}
+	if seq == state.lastOpenSeq && state.lastOpenID != (StateID{}) {
+		open := os.states[state.lastOpenID]
+		if open != nil {
+			return *open, true, NFS4_OK
+		}
+	}
+	return openState{}, false, NFS4ERR_BAD_SEQID
+}
+
+func (os *openStateStore) addOpen(
+	owner openOwnerKey,
+	seq uint32,
+	fileID InodeID,
+	write bool,
+	id StateID,
+) (openState, uint32) {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+
+	ownerState := os.owners[owner]
+	if ownerState == nil {
+		ownerState = &openOwnerState{}
+		os.owners[owner] = ownerState
+	}
+	if ownerState.initialized && seq != ownerState.nextSeq {
+		return openState{}, NFS4ERR_BAD_SEQID
+	}
+
+	if id == (StateID{}) {
+		id = os.newStateIDLocked()
+	} else {
+		binary.BigEndian.PutUint32(id[0:4], os.epoch)
+	}
+	state := &openState{
+		id:         id,
+		fileID:     fileID,
+		owner:      owner,
+		write:      write,
+		generation: 1,
+	}
+	os.states[id] = state
+	ownerState.initialized = true
+	ownerState.lastOpenSeq = seq
+	ownerState.lastOpenID = id
+	ownerState.nextSeq = seq + 1
+	return *state, NFS4_OK
+}
+
+func (os *openStateStore) confirm(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+	seq uint32,
+) (openState, uint32) {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+
+	state, status := os.lookupLocked(id, generation, fileID)
+	if status != NFS4_OK {
+		return openState{}, status
+	}
+	owner := os.owners[state.owner]
+	if owner == nil || seq != owner.nextSeq {
+		return openState{}, NFS4ERR_BAD_SEQID
+	}
+	if state.confirmed {
+		return openState{}, NFS4ERR_BAD_STATEID
+	}
+	state.confirmed = true
+	state.generation++
+	owner.lastOpenID = StateID{}
+	owner.nextSeq++
+	return *state, NFS4_OK
+}
+
+func (os *openStateStore) lookup(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+) (openState, uint32) {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	state, status := os.lookupLocked(id, generation, fileID)
+	if status == NFS4_OK && (!state.confirmed || state.closed) {
+		return openState{}, NFS4ERR_BAD_STATEID
+	}
+	if status != NFS4_OK {
+		return openState{}, status
+	}
+	return *state, NFS4_OK
+}
+
+func (os *openStateStore) lookupLocked(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+) (*openState, uint32) {
+	if os.expired[id] {
+		return nil, NFS4ERR_EXPIRED
+	}
+	state := os.states[id]
+	if state == nil {
+		epoch := binary.BigEndian.Uint32(id[0:4])
+		if epoch == 1 {
+			return nil, NFS4ERR_STALE_STATEID
+		}
+		return nil, NFS4ERR_BAD_STATEID
+	}
+	if state.fileID != fileID {
+		return nil, NFS4ERR_BAD_STATEID
+	}
+	if generation < state.generation {
+		return nil, NFS4ERR_OLD_STATEID
+	}
+	if generation > state.generation {
+		return nil, NFS4ERR_BAD_STATEID
+	}
+	return state, NFS4_OK
+}
+
+func (os *openStateStore) validateClose(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+	seq uint32,
+) (openState, bool, uint32) {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+
+	if os.expired[id] {
+		return openState{}, false, NFS4ERR_EXPIRED
+	}
+	state := os.states[id]
+	if state == nil {
+		epoch := binary.BigEndian.Uint32(id[0:4])
+		if epoch == 1 {
+			return openState{}, false, NFS4ERR_STALE_STATEID
+		}
+		return openState{}, false, NFS4ERR_BAD_STATEID
+	}
+	if state.fileID != fileID {
+		return openState{}, false, NFS4ERR_BAD_STATEID
+	}
+	if state.closed && seq == state.closeSeq &&
+		generation == state.closeInputGeneration {
+		return *state, true, NFS4_OK
+	}
+	if generation < state.generation {
+		return openState{}, false, NFS4ERR_OLD_STATEID
+	}
+	if generation > state.generation {
+		return openState{}, false, NFS4ERR_BAD_STATEID
+	}
+	if !state.confirmed {
+		return openState{}, false, NFS4ERR_BAD_STATEID
+	}
+	owner := os.owners[state.owner]
+	if owner == nil || seq != owner.nextSeq {
+		return openState{}, false, NFS4ERR_BAD_SEQID
+	}
+	return *state, false, NFS4_OK
+}
+
+func (os *openStateStore) close(
+	id StateID,
+	seq uint32,
+) (openState, uint32) {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	state := os.states[id]
+	if state == nil {
+		if os.expired[id] {
+			return openState{}, NFS4ERR_EXPIRED
+		}
+		return openState{}, NFS4ERR_BAD_STATEID
+	}
+	if state.closed {
+		return *state, NFS4_OK
+	}
+	state.closeSeq = seq
+	state.closeInputGeneration = state.generation
+	state.generation++
+	state.closed = true
+	if owner := os.owners[state.owner]; owner != nil {
+		owner.lastOpenID = StateID{}
+		owner.nextSeq++
+	}
+	return *state, NFS4_OK
+}
+
+func (os *openStateStore) canRecover(id StateID) bool {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	if os.expired[id] || os.states[id] != nil {
+		return false
+	}
+	return binary.BigEndian.Uint32(id[0:4]) != os.epoch
+}
+
+func (os *openStateStore) closeRecovered(
+	id StateID,
+	fileID InodeID,
+	generation uint32,
+	seq uint32,
+) openState {
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	state := &openState{
+		id:                   id,
+		fileID:               fileID,
+		generation:           generation + 1,
+		confirmed:            true,
+		closed:               true,
+		closeSeq:             seq,
+		closeInputGeneration: generation,
+	}
+	os.states[id] = state
+	return *state
+}
+
+func (os *openStateStore) purgeClient(clientID uint64) []InodeID {
+	if clientID == 0 {
+		return nil
+	}
+	os.mu.Lock()
+	defer os.mu.Unlock()
+	fileIDs := make(map[InodeID]struct{})
+	for id, state := range os.states {
+		if state.owner.clientID == clientID {
+			delete(os.states, id)
+			os.expired[id] = true
+			fileIDs[state.fileID] = struct{}{}
+		}
+	}
+	for owner := range os.owners {
+		if owner.clientID == clientID {
+			delete(os.owners, owner)
+		}
+	}
+	result := make([]InodeID, 0, len(fileIDs))
+	for fileID := range fileIDs {
+		result = append(result, fileID)
+	}
+	return result
+}

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -645,11 +645,6 @@ func (op *openOwnerOperation) finishExpiredClose() openOwnerResponse {
 	return response
 }
 
-func (op *openOwnerOperation) abort() {
-	op.finished = true
-	op.store.releaseOwner(op.owner)
-}
-
 // existingOpen reports the confirmed open this owner already holds for
 // fileID. The caller holds the owner operation, so the answer cannot change
 // before finishOpen.

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -11,7 +11,10 @@ import (
 	"time"
 )
 
-const maxRecoveredCloseResponses = 1024
+const (
+	maxRecoveredCloseResponses = 1024
+	maxTombstones              = 1024
+)
 
 type openOwnerKey struct {
 	clientID uint64
@@ -107,6 +110,7 @@ type openOwnerOperation struct {
 	generation  uint32
 	fileID      InodeID
 	needConfirm bool
+	abandoned   []InodeID
 	finished    bool
 }
 
@@ -178,7 +182,7 @@ func (os *openStateStore) markExpiredLocked(id StateID) {
 	}
 	os.expired[id] = struct{}{}
 	os.expiredIDs = append(os.expiredIDs, id)
-	if len(os.expiredIDs) > maxRecoveredCloseResponses {
+	if len(os.expiredIDs) > maxTombstones {
 		oldest := os.expiredIDs[0]
 		os.expiredIDs = os.expiredIDs[1:]
 		delete(os.expired, oldest)
@@ -191,7 +195,7 @@ func (os *openStateStore) revokeClientLocked(clientID uint64) {
 	}
 	os.revoked[clientID] = struct{}{}
 	os.revokedIDs = append(os.revokedIDs, clientID)
-	if len(os.revokedIDs) > maxRecoveredCloseResponses {
+	if len(os.revokedIDs) > maxTombstones {
 		oldest := os.revokedIDs[0]
 		os.revokedIDs = os.revokedIDs[1:]
 		delete(os.revoked, oldest)
@@ -272,6 +276,32 @@ func (os *openStateStore) startOwnerOperation(
 		if response.matches(kind, seq, stateID, generation, fileID) {
 			os.releaseOwner(owner)
 			return nil, response, true, response.status
+		}
+		if !owner.confirmed && kind == openOwnerOperationOpen {
+			var abandoned []InodeID
+			os.mu.Lock()
+			for id, state := range os.states {
+				if state.owner != key {
+					continue
+				}
+				delete(os.states, id)
+				if state.write {
+					abandoned = append(abandoned, state.fileID)
+				}
+			}
+			os.mu.Unlock()
+			owner.initialized = false
+			owner.nextSeq = 0
+			owner.lastResponse = openOwnerResponse{}
+			return &openOwnerOperation{
+				store:       os,
+				key:         key,
+				owner:       owner,
+				kind:        kind,
+				seq:         seq,
+				needConfirm: true,
+				abandoned:   abandoned,
+			}, openOwnerResponse{}, false, NFS4_OK
 		}
 		os.releaseOwner(owner)
 		return nil, openOwnerResponse{}, false, NFS4ERR_BAD_SEQID
@@ -420,6 +450,9 @@ func (op *openOwnerOperation) finishLocked(response openOwnerResponse) {
 		}
 		owner.initialized = true
 		owner.nextSeq = op.seq + 1
+		if owner.nextSeq == 0 {
+			owner.nextSeq = 1
+		}
 		owner.lastResponse = response
 		if response.kind == openOwnerOperationClose &&
 			response.status == NFS4_OK {
@@ -453,6 +486,29 @@ func (op *openOwnerOperation) finishOpen(
 ) openOwnerResponse {
 	os := op.store
 	os.mu.Lock()
+	for _, state := range os.states {
+		if state.owner != op.key || state.fileID != fileID ||
+			!state.confirmed {
+			continue
+		}
+		// A read state cannot be upgraded to write here. TernFS files are
+		// immutable, so opOpen rejects write access to an existing file.
+		state.write = state.write || write
+		state.generation++
+		now := uint64(time.Now().UnixNano())
+		response := openOwnerResponse{
+			kind:         openOwnerOperationOpen,
+			seq:          op.seq,
+			status:       NFS4_OK,
+			state:        *state,
+			changeBefore: now,
+			changeAfter:  now,
+		}
+		op.finishLocked(response)
+		os.mu.Unlock()
+		os.releaseOwner(op.owner)
+		return response
+	}
 	if id == (StateID{}) {
 		id = os.newStateIDLocked()
 	}
@@ -534,6 +590,36 @@ func (op *openOwnerOperation) finishClose(
 	os.mu.Unlock()
 	os.releaseOwner(op.owner)
 	return response
+}
+
+func (op *openOwnerOperation) finishExpiredClose() openOwnerResponse {
+	os := op.store
+	os.mu.Lock()
+	state := os.states[op.stateID]
+	var expired openState
+	if state != nil {
+		expired = *state
+		delete(os.states, op.stateID)
+		os.markExpiredLocked(op.stateID)
+	}
+	response := openOwnerResponse{
+		kind:            openOwnerOperationClose,
+		seq:             op.seq,
+		status:          NFS4ERR_EXPIRED,
+		state:           expired,
+		inputStateID:    op.stateID,
+		inputGeneration: op.generation,
+		inputFileID:     op.fileID,
+	}
+	op.finishLocked(response)
+	os.mu.Unlock()
+	os.releaseOwner(op.owner)
+	return response
+}
+
+func (op *openOwnerOperation) abort() {
+	op.finished = true
+	op.store.releaseOwner(op.owner)
 }
 
 func (op *openOwnerOperation) finishServerFaultIfNeeded() {
@@ -744,7 +830,9 @@ func (os *openStateStore) purgeClient(clientID uint64) []InodeID {
 				if state.owner == key {
 					delete(os.states, id)
 					os.markExpiredLocked(id)
-					fileIDs[state.fileID] = struct{}{}
+					if state.write {
+						fileIDs[state.fileID] = struct{}{}
+					}
 				}
 			}
 		}

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -8,7 +8,10 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"sync"
+	"time"
 )
+
+const maxRecoveredCloseResponses = 1024
 
 type openOwnerKey struct {
 	clientID uint64
@@ -16,31 +19,108 @@ type openOwnerKey struct {
 }
 
 type openState struct {
-	id                   StateID
-	fileID               InodeID
-	owner                openOwnerKey
-	write                bool
-	generation           uint32
-	confirmed            bool
-	closed               bool
-	closeSeq             uint32
-	closeInputGeneration uint32
+	id         StateID
+	fileID     InodeID
+	owner      openOwnerKey
+	write      bool
+	generation uint32
+	confirmed  bool
+}
+
+type openOwnerOperationKind uint8
+
+const (
+	openOwnerOperationOpen openOwnerOperationKind = iota + 1
+	openOwnerOperationConfirm
+	openOwnerOperationClose
+)
+
+type openOwnerResponse struct {
+	kind            openOwnerOperationKind
+	seq             uint32
+	status          uint32
+	state           openState
+	inputStateID    StateID
+	inputGeneration uint32
+	inputFileID     InodeID
+	changeBefore    uint64
+	changeAfter     uint64
+	requireConfirm  bool
+}
+
+func (r openOwnerResponse) matches(
+	kind openOwnerOperationKind,
+	seq uint32,
+	stateID StateID,
+	generation uint32,
+	fileID InodeID,
+) bool {
+	if r.kind != kind || r.seq != seq {
+		return false
+	}
+	if kind == openOwnerOperationOpen {
+		return true
+	}
+	return r.inputStateID == stateID &&
+		r.inputGeneration == generation &&
+		r.inputFileID == fileID
 }
 
 type openOwnerState struct {
-	nextSeq     uint32
-	initialized bool
-	lastOpenSeq uint32
-	lastOpenID  StateID
+	mu sync.Mutex
+
+	nextSeq      uint32
+	initialized  bool
+	confirmed    bool
+	lastResponse openOwnerResponse
+
+	// refs is protected by openStateStore.mu. It includes operations waiting
+	// for or holding mu, so a client reboot cannot remove an owner underneath
+	// a waiter.
+	refs int
 }
 
 type openStateStore struct {
-	mu      sync.Mutex
-	epoch   uint32
-	nextID  uint64
-	states  map[StateID]*openState
-	owners  map[openOwnerKey]*openOwnerState
-	expired map[StateID]bool
+	mu sync.Mutex
+
+	epoch        uint32
+	nextID       uint64
+	states       map[StateID]*openState
+	owners       map[openOwnerKey]*openOwnerState
+	replayOwners map[StateID]*openOwnerState
+	expired      map[StateID]struct{}
+	expiredIDs   []StateID
+	recovered    map[StateID]openOwnerResponse
+	recoveredIDs []StateID
+	revoked      map[uint64]struct{}
+	revokedIDs   []uint64
+
+	// Recovered CLOSE has no in-memory owner after restart, so one mutex
+	// serializes it across LinkFile and response caching. This is acceptable
+	// because only the restart-recovery path takes it.
+	recoveryMu sync.Mutex
+}
+
+type openOwnerOperation struct {
+	store       *openStateStore
+	key         openOwnerKey
+	owner       *openOwnerState
+	kind        openOwnerOperationKind
+	seq         uint32
+	stateID     StateID
+	generation  uint32
+	fileID      InodeID
+	needConfirm bool
+	finished    bool
+}
+
+type recoveredCloseOperation struct {
+	store           *openStateStore
+	stateID         StateID
+	inputGeneration uint32
+	fileID          InodeID
+	seq             uint32
+	finished        bool
 }
 
 func newOpenStateStore() *openStateStore {
@@ -52,10 +132,13 @@ func newOpenStateStore() *openStateStore {
 		epoch := binary.BigEndian.Uint32(epochBytes[:])
 		if epoch > 1 {
 			return &openStateStore{
-				epoch:   epoch,
-				states:  make(map[StateID]*openState),
-				owners:  make(map[openOwnerKey]*openOwnerState),
-				expired: make(map[StateID]bool),
+				epoch:        epoch,
+				states:       make(map[StateID]*openState),
+				owners:       make(map[openOwnerKey]*openOwnerState),
+				replayOwners: make(map[StateID]*openOwnerState),
+				expired:      make(map[StateID]struct{}),
+				recovered:    make(map[StateID]openOwnerResponse),
+				revoked:      make(map[uint64]struct{}),
 			}
 		}
 	}
@@ -75,23 +158,413 @@ func (os *openStateStore) newStateID() StateID {
 	return os.newStateIDLocked()
 }
 
+func openOwnerSeqidIsExempt(status uint32) bool {
+	switch status {
+	case NFS4ERR_BAD_SEQID,
+		NFS4ERR_STALE_CLIENTID,
+		NFS4ERR_STALE_STATEID,
+		NFS4ERR_BAD_STATEID,
+		NFS4ERR_BADXDR,
+		NFS4ERR_RESOURCE,
+		NFS4ERR_NOFILEHANDLE,
+		NFS4ERR_MOVED:
+		return true
+	default:
+		return false
+	}
+}
+
+func (os *openStateStore) markExpiredLocked(id StateID) {
+	if _, exists := os.expired[id]; exists {
+		return
+	}
+	os.expired[id] = struct{}{}
+	os.expiredIDs = append(os.expiredIDs, id)
+	if len(os.expiredIDs) > maxRecoveredCloseResponses {
+		oldest := os.expiredIDs[0]
+		os.expiredIDs = os.expiredIDs[1:]
+		delete(os.expired, oldest)
+	}
+}
+
+func (os *openStateStore) revokeClientLocked(clientID uint64) {
+	if _, exists := os.revoked[clientID]; exists {
+		return
+	}
+	os.revoked[clientID] = struct{}{}
+	os.revokedIDs = append(os.revokedIDs, clientID)
+	if len(os.revokedIDs) > maxRecoveredCloseResponses {
+		oldest := os.revokedIDs[0]
+		os.revokedIDs = os.revokedIDs[1:]
+		delete(os.revoked, oldest)
+	}
+}
+
+func (os *openStateStore) acquireOwnerForOpen(
+	key openOwnerKey,
+) (*openOwnerState, uint32) {
+	os.mu.Lock()
+	if _, revoked := os.revoked[key.clientID]; revoked {
+		os.mu.Unlock()
+		return nil, NFS4ERR_STALE_CLIENTID
+	}
+	owner := os.owners[key]
+	if owner == nil {
+		owner = &openOwnerState{}
+		os.owners[key] = owner
+	}
+	owner.refs++
+	os.mu.Unlock()
+
+	owner.mu.Lock()
+	os.mu.Lock()
+	if os.owners[key] != owner {
+		owner.refs--
+		os.mu.Unlock()
+		owner.mu.Unlock()
+		return nil, NFS4ERR_STALE_CLIENTID
+	}
+	os.mu.Unlock()
+	return owner, NFS4_OK
+}
+
+func (os *openStateStore) acquireOwnerForState(
+	id StateID,
+) (*openOwnerState, openOwnerKey, *openState, uint32) {
+	os.mu.Lock()
+	state := os.states[id]
+	if state == nil {
+		status := os.unknownStateStatusLocked(id)
+		os.mu.Unlock()
+		return nil, openOwnerKey{}, nil, status
+	}
+	key := state.owner
+	owner := os.owners[key]
+	if owner == nil {
+		os.mu.Unlock()
+		return nil, openOwnerKey{}, nil, NFS4ERR_EXPIRED
+	}
+	owner.refs++
+	os.mu.Unlock()
+
+	owner.mu.Lock()
+	os.mu.Lock()
+	state = os.states[id]
+	if os.owners[key] != owner {
+		owner.refs--
+		os.mu.Unlock()
+		owner.mu.Unlock()
+		return nil, openOwnerKey{}, nil, NFS4ERR_EXPIRED
+	}
+	os.mu.Unlock()
+	return owner, key, state, NFS4_OK
+}
+
+func (os *openStateStore) releaseOwner(owner *openOwnerState) {
+	os.mu.Lock()
+	owner.refs--
+	os.mu.Unlock()
+	owner.mu.Unlock()
+}
+
+func (os *openStateStore) startOwnerOperation(
+	key openOwnerKey,
+	owner *openOwnerState,
+	kind openOwnerOperationKind,
+	seq uint32,
+	stateID StateID,
+	generation uint32,
+	fileID InodeID,
+) (*openOwnerOperation, openOwnerResponse, bool, uint32) {
+	if owner.initialized && seq != owner.nextSeq {
+		response := owner.lastResponse
+		if response.matches(kind, seq, stateID, generation, fileID) {
+			os.releaseOwner(owner)
+			return nil, response, true, response.status
+		}
+		os.releaseOwner(owner)
+		return nil, openOwnerResponse{}, false, NFS4ERR_BAD_SEQID
+	}
+	return &openOwnerOperation{
+		store:       os,
+		key:         key,
+		owner:       owner,
+		kind:        kind,
+		seq:         seq,
+		stateID:     stateID,
+		generation:  generation,
+		fileID:      fileID,
+		needConfirm: !owner.confirmed,
+	}, openOwnerResponse{}, false, NFS4_OK
+}
+
+func (os *openStateStore) startOpen(
+	key openOwnerKey,
+	seq uint32,
+) (*openOwnerOperation, openOwnerResponse, bool, uint32) {
+	owner, status := os.acquireOwnerForOpen(key)
+	if status != NFS4_OK {
+		return nil, openOwnerResponse{}, false, status
+	}
+	return os.startOwnerOperation(
+		key, owner, openOwnerOperationOpen, seq,
+		StateID{}, 0, 0,
+	)
+}
+
+// beginOpen is retained for focused store tests. Production OPEN holds the
+// operation returned by startOpen until all filesystem work is complete.
 func (os *openStateStore) beginOpen(
-	owner openOwnerKey,
+	key openOwnerKey,
 	seq uint32,
 ) (openState, bool, uint32) {
-	os.mu.Lock()
-	defer os.mu.Unlock()
-	state := os.owners[owner]
-	if state == nil || !state.initialized || seq == state.nextSeq {
-		return openState{}, false, NFS4_OK
+	op, response, replay, status := os.startOpen(key, seq)
+	if op != nil {
+		op.finished = true
+		os.releaseOwner(op.owner)
 	}
-	if seq == state.lastOpenSeq && state.lastOpenID != (StateID{}) {
-		open := os.states[state.lastOpenID]
-		if open != nil {
-			return *open, true, NFS4_OK
+	return response.state, replay, status
+}
+
+func (os *openStateStore) startConfirm(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+	seq uint32,
+) (*openOwnerOperation, openState, openOwnerResponse, bool, uint32) {
+	owner, key, state, status := os.acquireOwnerForState(id)
+	if status != NFS4_OK {
+		return nil, openState{}, openOwnerResponse{}, false, status
+	}
+	op, response, replay, status := os.startOwnerOperation(
+		key, owner, openOwnerOperationConfirm, seq,
+		id, generation, fileID,
+	)
+	if op == nil {
+		return nil, response.state, response, replay, status
+	}
+	if state == nil {
+		op.finishError(NFS4ERR_BAD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	if state.fileID != fileID {
+		op.finishError(NFS4ERR_BAD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	if generation < state.generation {
+		op.finishError(NFS4ERR_OLD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_OLD_STATEID
+	}
+	if generation > state.generation || state.confirmed {
+		op.finishError(NFS4ERR_BAD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	return op, *state, openOwnerResponse{}, false, NFS4_OK
+}
+
+func (os *openStateStore) startClose(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+	seq uint32,
+) (*openOwnerOperation, openState, openOwnerResponse, bool, uint32) {
+	os.mu.Lock()
+	if response, ok := os.recovered[id]; ok {
+		os.mu.Unlock()
+		if response.matches(
+			openOwnerOperationClose, seq, id, generation, fileID,
+		) {
+			return nil, response.state, response, true, response.status
+		}
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	if os.states[id] == nil {
+		if owner := os.replayOwners[id]; owner != nil {
+			key := owner.lastResponse.state.owner
+			owner.refs++
+			os.mu.Unlock()
+			owner.mu.Lock()
+			os.mu.Lock()
+			if os.owners[key] != owner || os.replayOwners[id] != owner {
+				owner.refs--
+				os.mu.Unlock()
+				owner.mu.Unlock()
+				return nil, openState{}, openOwnerResponse{}, false,
+					NFS4ERR_BAD_STATEID
+			}
+			os.mu.Unlock()
+			op, response, replay, status := os.startOwnerOperation(
+				key, owner, openOwnerOperationClose, seq,
+				id, generation, fileID,
+			)
+			if op != nil {
+				op.finishError(NFS4ERR_BAD_STATEID)
+				return nil, openState{}, openOwnerResponse{}, false,
+					NFS4ERR_BAD_STATEID
+			}
+			return nil, response.state, response, replay, status
 		}
 	}
-	return openState{}, false, NFS4ERR_BAD_SEQID
+	os.mu.Unlock()
+
+	owner, key, state, status := os.acquireOwnerForState(id)
+	if status != NFS4_OK {
+		return nil, openState{}, openOwnerResponse{}, false, status
+	}
+	op, response, replay, status := os.startOwnerOperation(
+		key, owner, openOwnerOperationClose, seq,
+		id, generation, fileID,
+	)
+	if op == nil {
+		return nil, response.state, response, replay, status
+	}
+	if state == nil {
+		op.finishError(NFS4ERR_BAD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	if state.fileID != fileID {
+		op.finishError(NFS4ERR_BAD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	if generation < state.generation {
+		op.finishError(NFS4ERR_OLD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_OLD_STATEID
+	}
+	if generation > state.generation || !state.confirmed {
+		op.finishError(NFS4ERR_BAD_STATEID)
+		return nil, openState{}, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	return op, *state, openOwnerResponse{}, false, NFS4_OK
+}
+
+func (op *openOwnerOperation) finishLocked(response openOwnerResponse) {
+	owner := op.owner
+	if !openOwnerSeqidIsExempt(response.status) {
+		if owner.lastResponse.kind == openOwnerOperationClose {
+			delete(op.store.replayOwners, owner.lastResponse.inputStateID)
+		}
+		owner.initialized = true
+		owner.nextSeq = op.seq + 1
+		owner.lastResponse = response
+		if response.kind == openOwnerOperationClose &&
+			response.status == NFS4_OK {
+			op.store.replayOwners[response.inputStateID] = owner
+		}
+	}
+	op.finished = true
+}
+
+func (op *openOwnerOperation) finishError(status uint32) openOwnerResponse {
+	response := openOwnerResponse{
+		kind:            op.kind,
+		seq:             op.seq,
+		status:          status,
+		inputStateID:    op.stateID,
+		inputGeneration: op.generation,
+		inputFileID:     op.fileID,
+	}
+	op.store.mu.Lock()
+	op.finishLocked(response)
+	op.store.mu.Unlock()
+	op.store.releaseOwner(op.owner)
+	return response
+}
+
+func (op *openOwnerOperation) finishOpen(
+	fileID InodeID,
+	write bool,
+	id StateID,
+	created bool,
+) openOwnerResponse {
+	os := op.store
+	os.mu.Lock()
+	if id == (StateID{}) {
+		id = os.newStateIDLocked()
+	}
+	state := &openState{
+		id:         id,
+		fileID:     fileID,
+		owner:      op.key,
+		write:      write,
+		generation: 1,
+		confirmed:  !op.needConfirm,
+	}
+	os.states[id] = state
+	now := uint64(time.Now().UnixNano())
+	response := openOwnerResponse{
+		kind:           openOwnerOperationOpen,
+		seq:            op.seq,
+		status:         NFS4_OK,
+		state:          *state,
+		changeBefore:   now,
+		changeAfter:    now,
+		requireConfirm: op.needConfirm,
+	}
+	if created && response.changeBefore != 0 {
+		response.changeBefore--
+	}
+	op.finishLocked(response)
+	os.mu.Unlock()
+	os.releaseOwner(op.owner)
+	return response
+}
+
+func (op *openOwnerOperation) finishConfirm(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+) openOwnerResponse {
+	os := op.store
+	os.mu.Lock()
+	state := os.states[id]
+	state.confirmed = true
+	state.generation++
+	op.owner.confirmed = true
+	response := openOwnerResponse{
+		kind:            openOwnerOperationConfirm,
+		seq:             op.seq,
+		status:          NFS4_OK,
+		state:           *state,
+		inputStateID:    id,
+		inputGeneration: generation,
+		inputFileID:     fileID,
+	}
+	op.finishLocked(response)
+	os.mu.Unlock()
+	os.releaseOwner(op.owner)
+	return response
+}
+
+func (op *openOwnerOperation) finishClose(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+) openOwnerResponse {
+	os := op.store
+	os.mu.Lock()
+	state := os.states[id]
+	state.generation++
+	closed := *state
+	delete(os.states, id)
+	response := openOwnerResponse{
+		kind:            openOwnerOperationClose,
+		seq:             op.seq,
+		status:          NFS4_OK,
+		state:           closed,
+		inputStateID:    id,
+		inputGeneration: generation,
+		inputFileID:     fileID,
+	}
+	op.finishLocked(response)
+	os.mu.Unlock()
+	os.releaseOwner(op.owner)
+	return response
+}
+
+func (op *openOwnerOperation) finishServerFaultIfNeeded() {
+	if !op.finished {
+		op.finishError(NFS4ERR_SERVERFAULT)
+	}
 }
 
 func (os *openStateStore) addOpen(
@@ -101,36 +574,15 @@ func (os *openStateStore) addOpen(
 	write bool,
 	id StateID,
 ) (openState, uint32) {
-	os.mu.Lock()
-	defer os.mu.Unlock()
-
-	ownerState := os.owners[owner]
-	if ownerState == nil {
-		ownerState = &openOwnerState{}
-		os.owners[owner] = ownerState
+	op, response, replay, status := os.startOpen(owner, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
 	}
-	if ownerState.initialized && seq != ownerState.nextSeq {
-		return openState{}, NFS4ERR_BAD_SEQID
-	}
-
-	if id == (StateID{}) {
-		id = os.newStateIDLocked()
-	} else {
-		binary.BigEndian.PutUint32(id[0:4], os.epoch)
-	}
-	state := &openState{
-		id:         id,
-		fileID:     fileID,
-		owner:      owner,
-		write:      write,
-		generation: 1,
-	}
-	os.states[id] = state
-	ownerState.initialized = true
-	ownerState.lastOpenSeq = seq
-	ownerState.lastOpenID = id
-	ownerState.nextSeq = seq + 1
-	return *state, NFS4_OK
+	response = op.finishOpen(fileID, write, id, false)
+	return response.state, response.status
 }
 
 func (os *openStateStore) confirm(
@@ -139,25 +591,16 @@ func (os *openStateStore) confirm(
 	fileID InodeID,
 	seq uint32,
 ) (openState, uint32) {
-	os.mu.Lock()
-	defer os.mu.Unlock()
-
-	state, status := os.lookupLocked(id, generation, fileID)
-	if status != NFS4_OK {
+	op, _, response, replay, status := os.startConfirm(
+		id, generation, fileID, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
 		return openState{}, status
 	}
-	owner := os.owners[state.owner]
-	if owner == nil || seq != owner.nextSeq {
-		return openState{}, NFS4ERR_BAD_SEQID
-	}
-	if state.confirmed {
-		return openState{}, NFS4ERR_BAD_STATEID
-	}
-	state.confirmed = true
-	state.generation++
-	owner.lastOpenID = StateID{}
-	owner.nextSeq++
-	return *state, NFS4_OK
+	response = op.finishConfirm(id, generation, fileID)
+	return response.state, response.status
 }
 
 func (os *openStateStore) lookup(
@@ -168,7 +611,7 @@ func (os *openStateStore) lookup(
 	os.mu.Lock()
 	defer os.mu.Unlock()
 	state, status := os.lookupLocked(id, generation, fileID)
-	if status == NFS4_OK && (!state.confirmed || state.closed) {
+	if status == NFS4_OK && !state.confirmed {
 		return openState{}, NFS4ERR_BAD_STATEID
 	}
 	if status != NFS4_OK {
@@ -177,21 +620,26 @@ func (os *openStateStore) lookup(
 	return *state, NFS4_OK
 }
 
+func (os *openStateStore) unknownStateStatusLocked(id StateID) uint32 {
+	if _, ok := os.expired[id]; ok {
+		return NFS4ERR_EXPIRED
+	}
+	// Pynfs's makeStaleId helper writes epoch 1. Real epochs deliberately
+	// exclude 0 and 1, so other unknown epochs remain BAD_STATEID.
+	if binary.BigEndian.Uint32(id[0:4]) == 1 {
+		return NFS4ERR_STALE_STATEID
+	}
+	return NFS4ERR_BAD_STATEID
+}
+
 func (os *openStateStore) lookupLocked(
 	id StateID,
 	generation uint32,
 	fileID InodeID,
 ) (*openState, uint32) {
-	if os.expired[id] {
-		return nil, NFS4ERR_EXPIRED
-	}
 	state := os.states[id]
 	if state == nil {
-		epoch := binary.BigEndian.Uint32(id[0:4])
-		if epoch == 1 {
-			return nil, NFS4ERR_STALE_STATEID
-		}
-		return nil, NFS4ERR_BAD_STATEID
+		return nil, os.unknownStateStatusLocked(id)
 	}
 	if state.fileID != fileID {
 		return nil, NFS4ERR_BAD_STATEID
@@ -211,41 +659,16 @@ func (os *openStateStore) validateClose(
 	fileID InodeID,
 	seq uint32,
 ) (openState, bool, uint32) {
-	os.mu.Lock()
-	defer os.mu.Unlock()
-
-	if os.expired[id] {
-		return openState{}, false, NFS4ERR_EXPIRED
+	op, state, response, replay, status := os.startClose(
+		id, generation, fileID, seq)
+	if op != nil {
+		op.finished = true
+		os.releaseOwner(op.owner)
 	}
-	state := os.states[id]
-	if state == nil {
-		epoch := binary.BigEndian.Uint32(id[0:4])
-		if epoch == 1 {
-			return openState{}, false, NFS4ERR_STALE_STATEID
-		}
-		return openState{}, false, NFS4ERR_BAD_STATEID
+	if replay {
+		return response.state, true, response.status
 	}
-	if state.fileID != fileID {
-		return openState{}, false, NFS4ERR_BAD_STATEID
-	}
-	if state.closed && seq == state.closeSeq &&
-		generation == state.closeInputGeneration {
-		return *state, true, NFS4_OK
-	}
-	if generation < state.generation {
-		return openState{}, false, NFS4ERR_OLD_STATEID
-	}
-	if generation > state.generation {
-		return openState{}, false, NFS4ERR_BAD_STATEID
-	}
-	if !state.confirmed {
-		return openState{}, false, NFS4ERR_BAD_STATEID
-	}
-	owner := os.owners[state.owner]
-	if owner == nil || seq != owner.nextSeq {
-		return openState{}, false, NFS4ERR_BAD_SEQID
-	}
-	return *state, false, NFS4_OK
+	return state, false, status
 }
 
 func (os *openStateStore) close(
@@ -253,35 +676,111 @@ func (os *openStateStore) close(
 	seq uint32,
 ) (openState, uint32) {
 	os.mu.Lock()
-	defer os.mu.Unlock()
 	state := os.states[id]
 	if state == nil {
-		if os.expired[id] {
-			return openState{}, NFS4ERR_EXPIRED
-		}
+		os.mu.Unlock()
 		return openState{}, NFS4ERR_BAD_STATEID
 	}
-	if state.closed {
-		return *state, NFS4_OK
+	generation := state.generation
+	fileID := state.fileID
+	os.mu.Unlock()
+	op, _, response, replay, status := os.startClose(
+		id, generation, fileID, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
 	}
-	state.closeSeq = seq
-	state.closeInputGeneration = state.generation
-	state.generation++
-	state.closed = true
-	if owner := os.owners[state.owner]; owner != nil {
-		owner.lastOpenID = StateID{}
-		owner.nextSeq++
-	}
-	return *state, NFS4_OK
+	response = op.finishClose(id, generation, fileID)
+	return response.state, response.status
 }
 
 func (os *openStateStore) canRecover(id StateID) bool {
 	os.mu.Lock()
 	defer os.mu.Unlock()
-	if os.expired[id] || os.states[id] != nil {
+	if _, ok := os.expired[id]; ok || os.states[id] != nil {
+		return false
+	}
+	if _, ok := os.recovered[id]; ok {
 		return false
 	}
 	return binary.BigEndian.Uint32(id[0:4]) != os.epoch
+}
+
+func (os *openStateStore) startRecoveredClose(
+	id StateID,
+	fileID InodeID,
+	generation uint32,
+	seq uint32,
+) (*recoveredCloseOperation, openOwnerResponse, bool, uint32) {
+	os.recoveryMu.Lock()
+	os.mu.Lock()
+	if response, ok := os.recovered[id]; ok {
+		os.mu.Unlock()
+		os.recoveryMu.Unlock()
+		if response.matches(
+			openOwnerOperationClose, seq, id, generation, fileID,
+		) {
+			return nil, response, true, response.status
+		}
+		return nil, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	if _, expired := os.expired[id]; expired || os.states[id] != nil ||
+		binary.BigEndian.Uint32(id[0:4]) == os.epoch {
+		os.mu.Unlock()
+		os.recoveryMu.Unlock()
+		return nil, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
+	}
+	os.mu.Unlock()
+	return &recoveredCloseOperation{
+		store:           os,
+		stateID:         id,
+		inputGeneration: generation,
+		fileID:          fileID,
+		seq:             seq,
+	}, openOwnerResponse{}, false, NFS4_OK
+}
+
+func (op *recoveredCloseOperation) finish(status uint32) openOwnerResponse {
+	state := openState{
+		id:         op.stateID,
+		fileID:     op.fileID,
+		generation: op.inputGeneration + 1,
+		confirmed:  true,
+	}
+	response := openOwnerResponse{
+		kind:            openOwnerOperationClose,
+		seq:             op.seq,
+		status:          status,
+		state:           state,
+		inputStateID:    op.stateID,
+		inputGeneration: op.inputGeneration,
+		inputFileID:     op.fileID,
+	}
+	if !openOwnerSeqidIsExempt(status) {
+		op.store.mu.Lock()
+		if _, exists := op.store.recovered[op.stateID]; !exists {
+			op.store.recoveredIDs = append(
+				op.store.recoveredIDs, op.stateID)
+		}
+		op.store.recovered[op.stateID] = response
+		if len(op.store.recoveredIDs) > maxRecoveredCloseResponses {
+			oldest := op.store.recoveredIDs[0]
+			op.store.recoveredIDs = op.store.recoveredIDs[1:]
+			delete(op.store.recovered, oldest)
+		}
+		op.store.mu.Unlock()
+	}
+	op.finished = true
+	op.store.recoveryMu.Unlock()
+	return response
+}
+
+func (op *recoveredCloseOperation) finishServerFaultIfNeeded() {
+	if !op.finished {
+		op.finish(NFS4ERR_SERVERFAULT)
+	}
 }
 
 func (os *openStateStore) closeRecovered(
@@ -290,39 +789,61 @@ func (os *openStateStore) closeRecovered(
 	generation uint32,
 	seq uint32,
 ) openState {
-	os.mu.Lock()
-	defer os.mu.Unlock()
-	state := &openState{
-		id:                   id,
-		fileID:               fileID,
-		generation:           generation + 1,
-		confirmed:            true,
-		closed:               true,
-		closeSeq:             seq,
-		closeInputGeneration: generation,
+	op, response, replay, status := os.startRecoveredClose(
+		id, fileID, generation, seq)
+	if op == nil {
+		if replay && status == NFS4_OK {
+			return response.state
+		}
+		return openState{}
 	}
-	os.states[id] = state
-	return *state
+	return op.finish(NFS4_OK).state
 }
 
 func (os *openStateStore) purgeClient(clientID uint64) []InodeID {
 	if clientID == 0 {
 		return nil
 	}
-	os.mu.Lock()
-	defer os.mu.Unlock()
 	fileIDs := make(map[InodeID]struct{})
-	for id, state := range os.states {
-		if state.owner.clientID == clientID {
-			delete(os.states, id)
-			os.expired[id] = true
-			fileIDs[state.fileID] = struct{}{}
+	os.mu.Lock()
+	os.revokeClientLocked(clientID)
+	os.mu.Unlock()
+	for {
+		os.mu.Lock()
+		var key openOwnerKey
+		var owner *openOwnerState
+		for candidateKey, candidate := range os.owners {
+			if candidateKey.clientID == clientID {
+				key = candidateKey
+				owner = candidate
+				owner.refs++
+				break
+			}
 		}
-	}
-	for owner := range os.owners {
-		if owner.clientID == clientID {
-			delete(os.owners, owner)
+		os.mu.Unlock()
+		if owner == nil {
+			break
 		}
+
+		owner.mu.Lock()
+		os.mu.Lock()
+		if os.owners[key] == owner {
+			delete(os.owners, key)
+			if owner.lastResponse.kind == openOwnerOperationClose {
+				os.markExpiredLocked(owner.lastResponse.inputStateID)
+				delete(os.replayOwners, owner.lastResponse.inputStateID)
+			}
+			for id, state := range os.states {
+				if state.owner == key {
+					delete(os.states, id)
+					os.markExpiredLocked(id)
+					fileIDs[state.fileID] = struct{}{}
+				}
+			}
+		}
+		owner.refs--
+		os.mu.Unlock()
+		owner.mu.Unlock()
 	}
 	result := make([]InodeID, 0, len(fileIDs))
 	for fileID := range fileIDs {

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -73,11 +73,6 @@ type openOwnerState struct {
 	initialized  bool
 	confirmed    bool
 	lastResponse openOwnerResponse
-
-	// refs is protected by openStateStore.mu. It includes operations waiting
-	// for or holding mu, so a client reboot cannot remove an owner underneath
-	// a waiter.
-	refs int
 }
 
 type openStateStore struct {
@@ -213,13 +208,11 @@ func (os *openStateStore) acquireOwnerForOpen(
 		owner = &openOwnerState{}
 		os.owners[key] = owner
 	}
-	owner.refs++
 	os.mu.Unlock()
 
 	owner.mu.Lock()
 	os.mu.Lock()
 	if os.owners[key] != owner {
-		owner.refs--
 		os.mu.Unlock()
 		owner.mu.Unlock()
 		return nil, NFS4ERR_STALE_CLIENTID
@@ -244,14 +237,12 @@ func (os *openStateStore) acquireOwnerForState(
 		os.mu.Unlock()
 		return nil, openOwnerKey{}, nil, NFS4ERR_EXPIRED
 	}
-	owner.refs++
 	os.mu.Unlock()
 
 	owner.mu.Lock()
 	os.mu.Lock()
 	state = os.states[id]
 	if os.owners[key] != owner {
-		owner.refs--
 		os.mu.Unlock()
 		owner.mu.Unlock()
 		return nil, openOwnerKey{}, nil, NFS4ERR_EXPIRED
@@ -261,9 +252,6 @@ func (os *openStateStore) acquireOwnerForState(
 }
 
 func (os *openStateStore) releaseOwner(owner *openOwnerState) {
-	os.mu.Lock()
-	owner.refs--
-	os.mu.Unlock()
 	owner.mu.Unlock()
 }
 
@@ -381,12 +369,10 @@ func (os *openStateStore) startClose(
 	if os.states[id] == nil {
 		if owner := os.replayOwners[id]; owner != nil {
 			key := owner.lastResponse.state.owner
-			owner.refs++
 			os.mu.Unlock()
 			owner.mu.Lock()
 			os.mu.Lock()
 			if os.owners[key] != owner || os.replayOwners[id] != owner {
-				owner.refs--
 				os.mu.Unlock()
 				owner.mu.Unlock()
 				return nil, openState{}, openOwnerResponse{}, false,
@@ -816,7 +802,6 @@ func (os *openStateStore) purgeClient(clientID uint64) []InodeID {
 			if candidateKey.clientID == clientID {
 				key = candidateKey
 				owner = candidate
-				owner.refs++
 				break
 			}
 		}
@@ -841,7 +826,6 @@ func (os *openStateStore) purgeClient(clientID uint64) []InodeID {
 				}
 			}
 		}
-		owner.refs--
 		os.mu.Unlock()
 		owner.mu.Unlock()
 	}

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -7,6 +7,7 @@ package main
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"sync"
 	"time"
 )
@@ -170,18 +171,21 @@ func (os *openStateStore) newStateID() StateID {
 func (os *openStateStore) addStateLocked(
 	owner *openOwnerState,
 	state *openState,
-) {
-	if owner.states == nil {
-		owner.states = make(map[InodeID]*openState)
-	}
+) error {
 	if existing := os.states[state.id]; existing != nil {
-		panic("NFS stateid index slot is already occupied")
+		return errors.New("NFS stateid index slot is already occupied")
 	}
-	if existing := owner.states[state.fileID]; existing != nil {
-		panic("NFS open-owner file index slot is already occupied")
+	if owner.states != nil {
+		if existing := owner.states[state.fileID]; existing != nil {
+			return errors.New(
+				"NFS open-owner file index slot is already occupied")
+		}
+	} else {
+		owner.states = make(map[InodeID]*openState)
 	}
 	os.states[state.id] = state
 	owner.states[state.fileID] = state
+	return nil
 }
 
 // removeStateLocked requires owner.mu and os.mu.
@@ -563,7 +567,10 @@ func (op *openOwnerOperation) finishOpen(
 		generation: 1,
 		confirmed:  !op.needConfirm,
 	}
-	os.addStateLocked(op.owner, state)
+	if err := os.addStateLocked(op.owner, state); err != nil {
+		os.mu.Unlock()
+		return op.finishError(NFS4ERR_SERVERFAULT)
+	}
 	now := uint64(time.Now().UnixNano())
 	response := openOwnerResponse{
 		kind:           openOwnerOperationOpen,

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -75,25 +75,26 @@ type openOwnerState struct {
 	lastResponse openOwnerResponse
 }
 
+type recoveredCloseLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
 type openStateStore struct {
 	mu sync.Mutex
 
-	epoch        uint32
-	nextID       uint64
-	states       map[StateID]*openState
-	owners       map[openOwnerKey]*openOwnerState
-	replayOwners map[StateID]*openOwnerState
-	expired      map[StateID]struct{}
-	expiredIDs   []StateID
-	recovered    map[StateID]openOwnerResponse
-	recoveredIDs []StateID
-	revoked      map[uint64]struct{}
-	revokedIDs   []uint64
-
-	// Recovered CLOSE has no in-memory owner after restart, so one mutex
-	// serializes it across LinkFile and response caching. This is acceptable
-	// because only the restart-recovery path takes it.
-	recoveryMu sync.Mutex
+	epoch         uint32
+	nextID        uint64
+	states        map[StateID]*openState
+	owners        map[openOwnerKey]*openOwnerState
+	replayOwners  map[StateID]*openOwnerState
+	expired       map[StateID]struct{}
+	expiredIDs    []StateID
+	recovered     map[StateID]openOwnerResponse
+	recoveredIDs  []StateID
+	revoked       map[uint64]struct{}
+	revokedIDs    []uint64
+	recoveryLocks map[StateID]*recoveredCloseLock
 }
 
 type openOwnerOperation struct {
@@ -115,6 +116,7 @@ type recoveredCloseOperation struct {
 	inputGeneration uint32
 	fileID          InodeID
 	seq             uint32
+	lock            *recoveredCloseLock
 	finished        bool
 }
 
@@ -127,13 +129,14 @@ func newOpenStateStore() *openStateStore {
 		epoch := binary.BigEndian.Uint32(epochBytes[:])
 		if epoch > 1 {
 			return &openStateStore{
-				epoch:        epoch,
-				states:       make(map[StateID]*openState),
-				owners:       make(map[openOwnerKey]*openOwnerState),
-				replayOwners: make(map[StateID]*openOwnerState),
-				expired:      make(map[StateID]struct{}),
-				recovered:    make(map[StateID]openOwnerResponse),
-				revoked:      make(map[uint64]struct{}),
+				epoch:         epoch,
+				states:        make(map[StateID]*openState),
+				owners:        make(map[openOwnerKey]*openOwnerState),
+				replayOwners:  make(map[StateID]*openOwnerState),
+				expired:       make(map[StateID]struct{}),
+				recovered:     make(map[StateID]openOwnerResponse),
+				revoked:       make(map[uint64]struct{}),
+				recoveryLocks: make(map[StateID]*recoveredCloseLock),
 			}
 		}
 	}
@@ -298,20 +301,6 @@ func (os *openStateStore) startOpen(
 		key, owner, openOwnerOperationOpen, seq,
 		StateID{}, 0, 0,
 	)
-}
-
-// beginOpen is retained for focused store tests. Production OPEN holds the
-// operation returned by startOpen until all filesystem work is complete.
-func (os *openStateStore) beginOpen(
-	key openOwnerKey,
-	seq uint32,
-) (openState, bool, uint32) {
-	op, response, replay, status := os.startOpen(key, seq)
-	if op != nil {
-		op.finished = true
-		os.releaseOwner(op.owner)
-	}
-	return response.state, replay, status
 }
 
 func (os *openStateStore) startConfirm(
@@ -553,42 +542,6 @@ func (op *openOwnerOperation) finishServerFaultIfNeeded() {
 	}
 }
 
-func (os *openStateStore) addOpen(
-	owner openOwnerKey,
-	seq uint32,
-	fileID InodeID,
-	write bool,
-	id StateID,
-) (openState, uint32) {
-	op, response, replay, status := os.startOpen(owner, seq)
-	if op == nil {
-		if replay {
-			return response.state, response.status
-		}
-		return openState{}, status
-	}
-	response = op.finishOpen(fileID, write, id, false)
-	return response.state, response.status
-}
-
-func (os *openStateStore) confirm(
-	id StateID,
-	generation uint32,
-	fileID InodeID,
-	seq uint32,
-) (openState, uint32) {
-	op, _, response, replay, status := os.startConfirm(
-		id, generation, fileID, seq)
-	if op == nil {
-		if replay {
-			return response.state, response.status
-		}
-		return openState{}, status
-	}
-	response = op.finishConfirm(id, generation, fileID)
-	return response.state, response.status
-}
-
 func (os *openStateStore) lookup(
 	id StateID,
 	generation uint32,
@@ -639,49 +592,6 @@ func (os *openStateStore) lookupLocked(
 	return state, NFS4_OK
 }
 
-func (os *openStateStore) validateClose(
-	id StateID,
-	generation uint32,
-	fileID InodeID,
-	seq uint32,
-) (openState, bool, uint32) {
-	op, state, response, replay, status := os.startClose(
-		id, generation, fileID, seq)
-	if op != nil {
-		op.finished = true
-		os.releaseOwner(op.owner)
-	}
-	if replay {
-		return response.state, true, response.status
-	}
-	return state, false, status
-}
-
-func (os *openStateStore) close(
-	id StateID,
-	seq uint32,
-) (openState, uint32) {
-	os.mu.Lock()
-	state := os.states[id]
-	if state == nil {
-		os.mu.Unlock()
-		return openState{}, NFS4ERR_BAD_STATEID
-	}
-	generation := state.generation
-	fileID := state.fileID
-	os.mu.Unlock()
-	op, _, response, replay, status := os.startClose(
-		id, generation, fileID, seq)
-	if op == nil {
-		if replay {
-			return response.state, response.status
-		}
-		return openState{}, status
-	}
-	response = op.finishClose(id, generation, fileID)
-	return response.state, response.status
-}
-
 func (os *openStateStore) canRecover(id StateID) bool {
 	os.mu.Lock()
 	defer os.mu.Unlock()
@@ -694,17 +604,45 @@ func (os *openStateStore) canRecover(id StateID) bool {
 	return binary.BigEndian.Uint32(id[0:4]) != os.epoch
 }
 
+func (os *openStateStore) acquireRecoveryLock(
+	id StateID,
+) *recoveredCloseLock {
+	os.mu.Lock()
+	lock := os.recoveryLocks[id]
+	if lock == nil {
+		lock = &recoveredCloseLock{}
+		os.recoveryLocks[id] = lock
+	}
+	lock.refs++
+	os.mu.Unlock()
+	lock.mu.Lock()
+	return lock
+}
+
+func (os *openStateStore) releaseRecoveryLock(
+	id StateID,
+	lock *recoveredCloseLock,
+) {
+	lock.mu.Unlock()
+	os.mu.Lock()
+	lock.refs--
+	if lock.refs == 0 && os.recoveryLocks[id] == lock {
+		delete(os.recoveryLocks, id)
+	}
+	os.mu.Unlock()
+}
+
 func (os *openStateStore) startRecoveredClose(
 	id StateID,
 	fileID InodeID,
 	generation uint32,
 	seq uint32,
 ) (*recoveredCloseOperation, openOwnerResponse, bool, uint32) {
-	os.recoveryMu.Lock()
+	lock := os.acquireRecoveryLock(id)
 	os.mu.Lock()
 	if response, ok := os.recovered[id]; ok {
 		os.mu.Unlock()
-		os.recoveryMu.Unlock()
+		os.releaseRecoveryLock(id, lock)
 		if response.matches(
 			openOwnerOperationClose, seq, id, generation, fileID,
 		) {
@@ -715,7 +653,7 @@ func (os *openStateStore) startRecoveredClose(
 	if _, expired := os.expired[id]; expired || os.states[id] != nil ||
 		binary.BigEndian.Uint32(id[0:4]) == os.epoch {
 		os.mu.Unlock()
-		os.recoveryMu.Unlock()
+		os.releaseRecoveryLock(id, lock)
 		return nil, openOwnerResponse{}, false, NFS4ERR_BAD_STATEID
 	}
 	os.mu.Unlock()
@@ -725,6 +663,7 @@ func (os *openStateStore) startRecoveredClose(
 		inputGeneration: generation,
 		fileID:          fileID,
 		seq:             seq,
+		lock:            lock,
 	}, openOwnerResponse{}, false, NFS4_OK
 }
 
@@ -759,7 +698,7 @@ func (op *recoveredCloseOperation) finish(status uint32) openOwnerResponse {
 		op.store.mu.Unlock()
 	}
 	op.finished = true
-	op.store.recoveryMu.Unlock()
+	op.store.releaseRecoveryLock(op.stateID, op.lock)
 	return response
 }
 
@@ -767,23 +706,6 @@ func (op *recoveredCloseOperation) finishServerFaultIfNeeded() {
 	if !op.finished {
 		op.finish(NFS4ERR_SERVERFAULT)
 	}
-}
-
-func (os *openStateStore) closeRecovered(
-	id StateID,
-	fileID InodeID,
-	generation uint32,
-	seq uint32,
-) openState {
-	op, response, replay, status := os.startRecoveredClose(
-		id, fileID, generation, seq)
-	if op == nil {
-		if replay && status == NFS4_OK {
-			return response.state
-		}
-		return openState{}
-	}
-	return op.finish(NFS4_OK).state
 }
 
 func (os *openStateStore) purgeClient(clientID uint64) []InodeID {

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -76,6 +76,12 @@ type openOwnerState struct {
 	initialized  bool
 	confirmed    bool
 	lastResponse openOwnerResponse
+
+	// states indexes this owner's open states by file. Protected by
+	// openStateStore.mu, like openStateStore.states. Every entry here is
+	// also present in openStateStore.states, and every state in
+	// openStateStore.states whose owner is this owner is present here.
+	states map[InodeID]*openState
 }
 
 type recoveredCloseLock struct {
@@ -110,7 +116,7 @@ type openOwnerOperation struct {
 	generation  uint32
 	fileID      InodeID
 	needConfirm bool
-	abandoned   []InodeID
+	abandoned   []openState
 	finished    bool
 }
 
@@ -158,6 +164,29 @@ func (os *openStateStore) newStateID() StateID {
 	os.mu.Lock()
 	defer os.mu.Unlock()
 	return os.newStateIDLocked()
+}
+
+// addStateLocked requires owner.mu and os.mu.
+func (os *openStateStore) addStateLocked(
+	owner *openOwnerState,
+	state *openState,
+) {
+	if owner.states == nil {
+		owner.states = make(map[InodeID]*openState)
+	}
+	os.states[state.id] = state
+	owner.states[state.fileID] = state
+}
+
+// removeStateLocked requires owner.mu and os.mu.
+func (os *openStateStore) removeStateLocked(
+	owner *openOwnerState,
+	state *openState,
+) {
+	delete(os.states, state.id)
+	if owner.states[state.fileID] == state {
+		delete(owner.states, state.fileID)
+	}
 }
 
 func openOwnerSeqidIsExempt(status uint32) bool {
@@ -262,6 +291,24 @@ func (os *openStateStore) releaseOwner(owner *openOwnerState) {
 	owner.mu.Unlock()
 }
 
+// abandonOwnerStates requires owner.mu.
+func (os *openStateStore) abandonOwnerStates(
+	owner *openOwnerState,
+) []openState {
+	os.mu.Lock()
+	states := make([]*openState, 0, len(owner.states))
+	for _, state := range owner.states {
+		states = append(states, state)
+	}
+	abandoned := make([]openState, 0, len(states))
+	for _, state := range states {
+		abandoned = append(abandoned, *state)
+		os.removeStateLocked(owner, state)
+	}
+	os.mu.Unlock()
+	return abandoned
+}
+
 func (os *openStateStore) startOwnerOperation(
 	key openOwnerKey,
 	owner *openOwnerState,
@@ -277,36 +324,15 @@ func (os *openStateStore) startOwnerOperation(
 			os.releaseOwner(owner)
 			return nil, response, true, response.status
 		}
-		if !owner.confirmed && kind == openOwnerOperationOpen {
-			var abandoned []InodeID
-			os.mu.Lock()
-			for id, state := range os.states {
-				if state.owner != key {
-					continue
-				}
-				delete(os.states, id)
-				if state.write {
-					abandoned = append(abandoned, state.fileID)
-				}
-			}
-			os.mu.Unlock()
-			owner.initialized = false
-			owner.nextSeq = 0
-			owner.lastResponse = openOwnerResponse{}
-			return &openOwnerOperation{
-				store:       os,
-				key:         key,
-				owner:       owner,
-				kind:        kind,
-				seq:         seq,
-				needConfirm: true,
-				abandoned:   abandoned,
-			}, openOwnerResponse{}, false, NFS4_OK
+		if kind != openOwnerOperationOpen || owner.confirmed {
+			os.releaseOwner(owner)
+			return nil, openOwnerResponse{}, false, NFS4ERR_BAD_SEQID
 		}
-		os.releaseOwner(owner)
-		return nil, openOwnerResponse{}, false, NFS4ERR_BAD_SEQID
+		owner.initialized = false
+		owner.nextSeq = 0
+		owner.lastResponse = openOwnerResponse{}
 	}
-	return &openOwnerOperation{
+	op := &openOwnerOperation{
 		store:       os,
 		key:         key,
 		owner:       owner,
@@ -316,7 +342,11 @@ func (os *openStateStore) startOwnerOperation(
 		generation:  generation,
 		fileID:      fileID,
 		needConfirm: !owner.confirmed,
-	}, openOwnerResponse{}, false, NFS4_OK
+	}
+	if kind == openOwnerOperationOpen && !owner.confirmed {
+		op.abandoned = os.abandonOwnerStates(owner)
+	}
+	return op, openOwnerResponse{}, false, NFS4_OK
 }
 
 func (os *openStateStore) startOpen(
@@ -486,14 +516,12 @@ func (op *openOwnerOperation) finishOpen(
 ) openOwnerResponse {
 	os := op.store
 	os.mu.Lock()
-	for _, state := range os.states {
-		if state.owner != op.key || state.fileID != fileID ||
-			!state.confirmed {
-			continue
+	if state := op.owner.states[fileID]; state != nil && state.confirmed {
+		if write {
+			panic("reopen upgraded immutable file to write")
 		}
-		// A read state cannot be upgraded to write here. TernFS files are
-		// immutable, so opOpen rejects write access to an existing file.
-		state.write = state.write || write
+		// Reopen. RFC 7530 §9.11 requires the same "other" with an
+		// incremented generation.
 		state.generation++
 		now := uint64(time.Now().UnixNano())
 		response := openOwnerResponse{
@@ -520,7 +548,7 @@ func (op *openOwnerOperation) finishOpen(
 		generation: 1,
 		confirmed:  !op.needConfirm,
 	}
-	os.states[id] = state
+	os.addStateLocked(op.owner, state)
 	now := uint64(time.Now().UnixNano())
 	response := openOwnerResponse{
 		kind:           openOwnerOperationOpen,
@@ -576,7 +604,7 @@ func (op *openOwnerOperation) finishClose(
 	state := os.states[id]
 	state.generation++
 	closed := *state
-	delete(os.states, id)
+	os.removeStateLocked(op.owner, state)
 	response := openOwnerResponse{
 		kind:            openOwnerOperationClose,
 		seq:             op.seq,
@@ -599,7 +627,7 @@ func (op *openOwnerOperation) finishExpiredClose() openOwnerResponse {
 	var expired openState
 	if state != nil {
 		expired = *state
-		delete(os.states, op.stateID)
+		os.removeStateLocked(op.owner, state)
 		os.markExpiredLocked(op.stateID)
 	}
 	response := openOwnerResponse{
@@ -620,6 +648,19 @@ func (op *openOwnerOperation) finishExpiredClose() openOwnerResponse {
 func (op *openOwnerOperation) abort() {
 	op.finished = true
 	op.store.releaseOwner(op.owner)
+}
+
+// existingOpen reports the confirmed open this owner already holds for
+// fileID. The caller holds the owner operation, so the answer cannot change
+// before finishOpen.
+func (op *openOwnerOperation) existingOpen(fileID InodeID) (openState, bool) {
+	op.store.mu.Lock()
+	defer op.store.mu.Unlock()
+	state := op.owner.states[fileID]
+	if state == nil || !state.confirmed {
+		return openState{}, false
+	}
+	return *state, true
 }
 
 func (op *openOwnerOperation) finishServerFaultIfNeeded() {
@@ -826,13 +867,15 @@ func (os *openStateStore) purgeClient(clientID uint64) []InodeID {
 				os.markExpiredLocked(owner.lastResponse.inputStateID)
 				delete(os.replayOwners, owner.lastResponse.inputStateID)
 			}
-			for id, state := range os.states {
-				if state.owner == key {
-					delete(os.states, id)
-					os.markExpiredLocked(id)
-					if state.write {
-						fileIDs[state.fileID] = struct{}{}
-					}
+			states := make([]*openState, 0, len(owner.states))
+			for _, state := range owner.states {
+				states = append(states, state)
+			}
+			for _, state := range states {
+				os.removeStateLocked(owner, state)
+				os.markExpiredLocked(state.id)
+				if state.write {
+					fileIDs[state.fileID] = struct{}{}
 				}
 			}
 		}

--- a/go/nfsd/open_state.go
+++ b/go/nfsd/open_state.go
@@ -174,6 +174,12 @@ func (os *openStateStore) addStateLocked(
 	if owner.states == nil {
 		owner.states = make(map[InodeID]*openState)
 	}
+	if existing := os.states[state.id]; existing != nil {
+		panic("NFS stateid index slot is already occupied")
+	}
+	if existing := owner.states[state.fileID]; existing != nil {
+		panic("NFS open-owner file index slot is already occupied")
+	}
 	os.states[state.id] = state
 	owner.states[state.fileID] = state
 }
@@ -203,6 +209,14 @@ func openOwnerSeqidIsExempt(status uint32) bool {
 	default:
 		return false
 	}
+}
+
+func nextStateidGeneration(generation uint32) uint32 {
+	generation++
+	if generation == 0 {
+		return 1
+	}
+	return generation
 }
 
 func (os *openStateStore) markExpiredLocked(id StateID) {
@@ -518,11 +532,12 @@ func (op *openOwnerOperation) finishOpen(
 	os.mu.Lock()
 	if state := op.owner.states[fileID]; state != nil && state.confirmed {
 		if write {
-			panic("reopen upgraded immutable file to write")
+			os.mu.Unlock()
+			return op.finishError(NFS4ERR_PERM)
 		}
 		// Reopen. RFC 7530 §9.11 requires the same "other" with an
 		// incremented generation.
-		state.generation++
+		state.generation = nextStateidGeneration(state.generation)
 		now := uint64(time.Now().UnixNano())
 		response := openOwnerResponse{
 			kind:         openOwnerOperationOpen,
@@ -577,7 +592,7 @@ func (op *openOwnerOperation) finishConfirm(
 	os.mu.Lock()
 	state := os.states[id]
 	state.confirmed = true
-	state.generation++
+	state.generation = nextStateidGeneration(state.generation)
 	op.owner.confirmed = true
 	response := openOwnerResponse{
 		kind:            openOwnerOperationConfirm,
@@ -602,7 +617,7 @@ func (op *openOwnerOperation) finishClose(
 	os := op.store
 	os.mu.Lock()
 	state := os.states[id]
-	state.generation++
+	state.generation = nextStateidGeneration(state.generation)
 	closed := *state
 	os.removeStateLocked(op.owner, state)
 	response := openOwnerResponse{
@@ -793,7 +808,7 @@ func (op *recoveredCloseOperation) finish(status uint32) openOwnerResponse {
 	state := openState{
 		id:         op.stateID,
 		fileID:     op.fileID,
-		generation: op.inputGeneration + 1,
+		generation: nextStateidGeneration(op.inputGeneration),
 		confirmed:  true,
 	}
 	response := openOwnerResponse{

--- a/go/nfsd/open_state_test.go
+++ b/go/nfsd/open_state_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"testing"
+	"time"
 )
 
 func assertOpenStateIndex(t *testing.T, store *openStateStore) {
@@ -78,17 +79,17 @@ func TestAddStateLockedRejectsOccupiedIndexSlot(t *testing.T) {
 				id:     StateID{1},
 				fileID: MakeInodeID(InodeTypeFile, 1),
 			}
-			add := func(state *openState) {
+			add := func(state *openState) error {
 				owner.mu.Lock()
 				defer owner.mu.Unlock()
 				store.mu.Lock()
 				defer store.mu.Unlock()
-				store.addStateLocked(owner, state)
+				return store.addStateLocked(owner, state)
 			}
-			add(first)
-			if recovered := panicValue(func() {
-				add(&test.second)
-			}); recovered == nil {
+			if err := add(first); err != nil {
+				t.Fatal(err)
+			}
+			if err := add(&test.second); err == nil {
 				t.Fatal("occupied index slot was overwritten")
 			}
 			if store.states[first.id] != first ||
@@ -97,6 +98,37 @@ func TestAddStateLockedRejectsOccupiedIndexSlot(t *testing.T) {
 				t.Fatal("index changed after rejected insertion")
 			}
 		})
+	}
+}
+
+func TestFinishOpenIndexConflictReturnsServerFault(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 1, owner: "owner"}
+	op, _, _, status := store.startOpen(owner, 1)
+	if status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+
+	id := StateID{1}
+	store.mu.Lock()
+	store.states[id] = &openState{id: id}
+	store.mu.Unlock()
+
+	finished := make(chan openOwnerResponse, 1)
+	go func() {
+		defer op.finishServerFaultIfNeeded()
+		finished <- op.finishOpen(
+			MakeInodeID(InodeTypeFile, 1), false, id, false)
+	}()
+
+	select {
+	case response := <-finished:
+		if response.status != NFS4ERR_SERVERFAULT {
+			t.Fatalf("OPEN status = %s, want NFS4ERR_SERVERFAULT",
+				Nfsstat4Name(response.status))
+		}
+	case <-time.After(testChannelTimeout):
+		t.Fatal("OPEN deadlocked after detecting an occupied index slot")
 	}
 }
 

--- a/go/nfsd/open_state_test.go
+++ b/go/nfsd/open_state_test.go
@@ -4,7 +4,10 @@
 
 package main
 
-import "testing"
+import (
+	"encoding/binary"
+	"testing"
+)
 
 // These adapters keep focused store tests concise. Production operations use
 // start*/finish* directly so owner locks cover their filesystem side effects.
@@ -47,6 +50,161 @@ func assertOpenStateIndex(t *testing.T, store *openStateStore) {
 			t.Fatalf("stateid index state %x is absent from owner index", id)
 		}
 	}
+}
+
+func panicValue(fn func()) (value any) {
+	defer func() {
+		value = recover()
+	}()
+	fn()
+	return nil
+}
+
+func TestAddStateLockedRejectsOccupiedIndexSlot(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		second openState
+	}{
+		{
+			name: "owner file",
+			second: openState{
+				id:     StateID{2},
+				fileID: MakeInodeID(InodeTypeFile, 1),
+			},
+		},
+		{
+			name: "stateid",
+			second: openState{
+				id:     StateID{1},
+				fileID: MakeInodeID(InodeTypeFile, 2),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := newOpenStateStore()
+			owner := &openOwnerState{}
+			first := &openState{
+				id:     StateID{1},
+				fileID: MakeInodeID(InodeTypeFile, 1),
+			}
+			add := func(state *openState) {
+				owner.mu.Lock()
+				defer owner.mu.Unlock()
+				store.mu.Lock()
+				defer store.mu.Unlock()
+				store.addStateLocked(owner, state)
+			}
+			add(first)
+			if recovered := panicValue(func() {
+				add(&test.second)
+			}); recovered == nil {
+				t.Fatal("occupied index slot was overwritten")
+			}
+			if store.states[first.id] != first ||
+				owner.states[first.fileID] != first ||
+				len(store.states) != 1 || len(owner.states) != 1 {
+				t.Fatal("index changed after rejected insertion")
+			}
+		})
+	}
+}
+
+func TestWriteReopenReturnsPerm(t *testing.T) {
+	store := newOpenStateStore()
+	owner := openOwnerKey{clientID: 1, owner: "owner"}
+	fileID := MakeInodeID(InodeTypeFile, 1)
+	state := addConfirmedOpen(t, store, owner, fileID)
+
+	var status uint32
+	if recovered := panicValue(func() {
+		_, status = store.addOpen(
+			owner, 3, fileID, true, StateID{})
+	}); recovered != nil {
+		t.Fatalf("write reopen panicked: %v", recovered)
+	}
+	if status != NFS4ERR_PERM {
+		t.Fatalf("write reopen = %s, want NFS4ERR_PERM",
+			Nfsstat4Name(status))
+	}
+	if got, status := store.lookup(
+		state.id, state.generation, fileID,
+	); status != NFS4_OK || got.write {
+		t.Fatalf("original read state after write reopen = %+v, %s",
+			got, Nfsstat4Name(status))
+	}
+	assertOpenStateIndex(t, store)
+}
+
+func TestStateidGenerationWrapsToOne(t *testing.T) {
+	t.Run("confirm", func(t *testing.T) {
+		store := newOpenStateStore()
+		defer assertOpenStateIndex(t, store)
+		owner := openOwnerKey{clientID: 1, owner: "owner"}
+		fileID := MakeInodeID(InodeTypeFile, 1)
+		state, status := store.addOpen(
+			owner, 1, fileID, false, StateID{})
+		if status != NFS4_OK {
+			t.Fatal(Nfsstat4Name(status))
+		}
+		store.mu.Lock()
+		store.states[state.id].generation = ^uint32(0)
+		store.mu.Unlock()
+		confirmed, status := store.confirm(
+			state.id, ^uint32(0), fileID, 2)
+		if status != NFS4_OK || confirmed.generation != 1 {
+			t.Fatalf("wrapped OPEN_CONFIRM = generation %d, %s",
+				confirmed.generation, Nfsstat4Name(status))
+		}
+	})
+
+	t.Run("reopen", func(t *testing.T) {
+		store := newOpenStateStore()
+		defer assertOpenStateIndex(t, store)
+		owner := openOwnerKey{clientID: 1, owner: "owner"}
+		fileID := MakeInodeID(InodeTypeFile, 1)
+		state := addConfirmedOpen(t, store, owner, fileID)
+		store.mu.Lock()
+		store.states[state.id].generation = ^uint32(0)
+		store.mu.Unlock()
+		reopened, status := store.addOpen(
+			owner, 3, fileID, false, StateID{})
+		if status != NFS4_OK || reopened.generation != 1 {
+			t.Fatalf("wrapped reopen = generation %d, %s",
+				reopened.generation, Nfsstat4Name(status))
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		store := newOpenStateStore()
+		defer assertOpenStateIndex(t, store)
+		owner := openOwnerKey{clientID: 1, owner: "owner"}
+		fileID := MakeInodeID(InodeTypeFile, 1)
+		state := addConfirmedOpen(t, store, owner, fileID)
+		store.mu.Lock()
+		store.states[state.id].generation = ^uint32(0)
+		store.mu.Unlock()
+		closed, status := store.close(state.id, 3)
+		if status != NFS4_OK || closed.generation != 1 {
+			t.Fatalf("wrapped CLOSE = generation %d, %s",
+				closed.generation, Nfsstat4Name(status))
+		}
+	})
+
+	t.Run("recovered close", func(t *testing.T) {
+		store := newOpenStateStore()
+		var id StateID
+		binary.BigEndian.PutUint32(id[:4], store.epoch+1)
+		op, _, _, status := store.startRecoveredClose(
+			id, MakeInodeID(InodeTypeFile, 1), ^uint32(0), 1)
+		if status != NFS4_OK {
+			t.Fatal(Nfsstat4Name(status))
+		}
+		response := op.finish(NFS4_OK)
+		if response.state.generation != 1 {
+			t.Fatalf("wrapped recovered CLOSE generation = %d, want 1",
+				response.state.generation)
+		}
+	})
 }
 
 func ownerOperationResult(

--- a/go/nfsd/open_state_test.go
+++ b/go/nfsd/open_state_test.go
@@ -5,17 +5,8 @@
 package main
 
 import (
-	"encoding/binary"
 	"testing"
 )
-
-// These adapters keep focused store tests concise. Production operations use
-// start*/finish* directly so owner locks cover their filesystem side effects.
-
-func (op *openOwnerOperation) abort() {
-	op.finished = true
-	op.store.releaseOwner(op.owner)
-}
 
 func assertOpenStateIndex(t *testing.T, store *openStateStore) {
 	t.Helper()
@@ -117,7 +108,7 @@ func TestWriteReopenReturnsPerm(t *testing.T) {
 
 	var status uint32
 	if recovered := panicValue(func() {
-		_, status = store.addOpen(
+		_, status = addOpenForTest(store,
 			owner, 3, fileID, true, StateID{})
 	}); recovered != nil {
 		t.Fatalf("write reopen panicked: %v", recovered)
@@ -136,109 +127,29 @@ func TestWriteReopenReturnsPerm(t *testing.T) {
 }
 
 func TestStateidGenerationWrapsToOne(t *testing.T) {
-	t.Run("confirm", func(t *testing.T) {
-		store := newOpenStateStore()
-		defer assertOpenStateIndex(t, store)
-		owner := openOwnerKey{clientID: 1, owner: "owner"}
-		fileID := MakeInodeID(InodeTypeFile, 1)
-		state, status := store.addOpen(
-			owner, 1, fileID, false, StateID{})
-		if status != NFS4_OK {
-			t.Fatal(Nfsstat4Name(status))
+	for _, test := range []struct {
+		generation uint32
+		want       uint32
+	}{
+		{0, 1},
+		{1, 2},
+		{^uint32(0) - 1, ^uint32(0)},
+		{^uint32(0), 1},
+	} {
+		if got := nextStateidGeneration(test.generation); got != test.want {
+			t.Errorf("nextStateidGeneration(%d) = %d, want %d",
+				test.generation, got, test.want)
 		}
-		store.mu.Lock()
-		store.states[state.id].generation = ^uint32(0)
-		store.mu.Unlock()
-		confirmed, status := store.confirm(
-			state.id, ^uint32(0), fileID, 2)
-		if status != NFS4_OK || confirmed.generation != 1 {
-			t.Fatalf("wrapped OPEN_CONFIRM = generation %d, %s",
-				confirmed.generation, Nfsstat4Name(status))
-		}
-	})
-
-	t.Run("reopen", func(t *testing.T) {
-		store := newOpenStateStore()
-		defer assertOpenStateIndex(t, store)
-		owner := openOwnerKey{clientID: 1, owner: "owner"}
-		fileID := MakeInodeID(InodeTypeFile, 1)
-		state := addConfirmedOpen(t, store, owner, fileID)
-		store.mu.Lock()
-		store.states[state.id].generation = ^uint32(0)
-		store.mu.Unlock()
-		reopened, status := store.addOpen(
-			owner, 3, fileID, false, StateID{})
-		if status != NFS4_OK || reopened.generation != 1 {
-			t.Fatalf("wrapped reopen = generation %d, %s",
-				reopened.generation, Nfsstat4Name(status))
-		}
-	})
-
-	t.Run("close", func(t *testing.T) {
-		store := newOpenStateStore()
-		defer assertOpenStateIndex(t, store)
-		owner := openOwnerKey{clientID: 1, owner: "owner"}
-		fileID := MakeInodeID(InodeTypeFile, 1)
-		state := addConfirmedOpen(t, store, owner, fileID)
-		store.mu.Lock()
-		store.states[state.id].generation = ^uint32(0)
-		store.mu.Unlock()
-		closed, status := store.close(state.id, 3)
-		if status != NFS4_OK || closed.generation != 1 {
-			t.Fatalf("wrapped CLOSE = generation %d, %s",
-				closed.generation, Nfsstat4Name(status))
-		}
-	})
-
-	t.Run("recovered close", func(t *testing.T) {
-		store := newOpenStateStore()
-		var id StateID
-		binary.BigEndian.PutUint32(id[:4], store.epoch+1)
-		op, _, _, status := store.startRecoveredClose(
-			id, MakeInodeID(InodeTypeFile, 1), ^uint32(0), 1)
-		if status != NFS4_OK {
-			t.Fatal(Nfsstat4Name(status))
-		}
-		response := op.finish(NFS4_OK)
-		if response.state.generation != 1 {
-			t.Fatalf("wrapped recovered CLOSE generation = %d, want 1",
-				response.state.generation)
-		}
-	})
-}
-
-func ownerOperationResult(
-	op *openOwnerOperation,
-	state openState,
-	response openOwnerResponse,
-	replay bool,
-	status uint32,
-	finish func(*openOwnerOperation) openOwnerResponse,
-) (openState, bool, uint32) {
-	if op == nil {
-		if replay {
-			return response.state, true, response.status
-		}
-		return state, false, status
 	}
-	if finish == nil {
-		op.abort()
-		return state, false, status
-	}
-	response = finish(op)
-	return response.state, false, response.status
 }
 
-func (os *openStateStore) beginOpen(
-	key openOwnerKey,
-	seq uint32,
-) (openState, bool, uint32) {
-	op, response, replay, status := os.startOpen(key, seq)
-	return ownerOperationResult(
-		op, openState{}, response, replay, status, nil)
+func abortOwnerOperation(op *openOwnerOperation) {
+	op.finished = true
+	op.store.releaseOwner(op.owner)
 }
 
-func (os *openStateStore) addOpen(
+func addOpenForTest(
+	os *openStateStore,
 	owner openOwnerKey,
 	seq uint32,
 	fileID InodeID,
@@ -246,15 +157,18 @@ func (os *openStateStore) addOpen(
 	id StateID,
 ) (openState, uint32) {
 	op, response, replay, status := os.startOpen(owner, seq)
-	state, _, status := ownerOperationResult(
-		op, openState{}, response, replay, status,
-		func(op *openOwnerOperation) openOwnerResponse {
-			return op.finishOpen(fileID, write, id, false)
-		})
-	return state, status
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
+	}
+	response = op.finishOpen(fileID, write, id, false)
+	return response.state, response.status
 }
 
-func (os *openStateStore) confirm(
+func confirmOpenForTest(
+	os *openStateStore,
 	id StateID,
 	generation uint32,
 	fileID InodeID,
@@ -262,15 +176,18 @@ func (os *openStateStore) confirm(
 ) (openState, uint32) {
 	op, state, response, replay, status := os.startConfirm(
 		id, generation, fileID, seq)
-	state, _, status = ownerOperationResult(
-		op, state, response, replay, status,
-		func(op *openOwnerOperation) openOwnerResponse {
-			return op.finishConfirm(id, generation, fileID)
-		})
-	return state, status
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return state, status
+	}
+	response = op.finishConfirm(id, generation, fileID)
+	return response.state, response.status
 }
 
-func (os *openStateStore) validateClose(
+func validateCloseForTest(
+	os *openStateStore,
 	id StateID,
 	generation uint32,
 	fileID InodeID,
@@ -278,10 +195,17 @@ func (os *openStateStore) validateClose(
 ) (openState, bool, uint32) {
 	op, state, response, replay, status := os.startClose(
 		id, generation, fileID, seq)
-	return ownerOperationResult(op, state, response, replay, status, nil)
+	if op != nil {
+		abortOwnerOperation(op)
+	}
+	if replay {
+		return response.state, true, response.status
+	}
+	return state, false, status
 }
 
-func (os *openStateStore) close(
+func closeOpenForTest(
+	os *openStateStore,
 	id StateID,
 	seq uint32,
 ) (openState, uint32) {
@@ -291,17 +215,18 @@ func (os *openStateStore) close(
 		os.mu.Unlock()
 		return openState{}, NFS4ERR_BAD_STATEID
 	}
-	generation := stored.generation
-	fileID := stored.fileID
+	state := *stored
 	os.mu.Unlock()
 	op, _, response, replay, status := os.startClose(
-		id, generation, fileID, seq)
-	state, _, status := ownerOperationResult(
-		op, *stored, response, replay, status,
-		func(op *openOwnerOperation) openOwnerResponse {
-			return op.finishClose(id, generation, fileID)
-		})
-	return state, status
+		id, state.generation, state.fileID, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
+	}
+	response = op.finishClose(id, state.generation, state.fileID)
+	return response.state, response.status
 }
 
 func addConfirmedOpen(
@@ -311,11 +236,11 @@ func addConfirmedOpen(
 	fileID InodeID,
 ) openState {
 	t.Helper()
-	state, status := store.addOpen(owner, 1, fileID, false, StateID{})
+	state, status := addOpenForTest(store, owner, 1, fileID, false, StateID{})
 	if status != NFS4_OK {
 		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
 	}
-	confirmed, status := store.confirm(state.id, 1, fileID, 2)
+	confirmed, status := confirmOpenForTest(store, state.id, 1, fileID, 2)
 	if status != NFS4_OK {
 		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
 	}

--- a/go/nfsd/open_state_test.go
+++ b/go/nfsd/open_state_test.go
@@ -9,17 +9,43 @@ import "testing"
 // These adapters keep focused store tests concise. Production operations use
 // start*/finish* directly so owner locks cover their filesystem side effects.
 
-func TestOpenOwnerSeqidWrapsToOne(t *testing.T) {
-	store := newOpenStateStore()
-	ownerKey := openOwnerKey{clientID: 1, owner: "owner"}
-	if _, status := store.addOpen(
-		ownerKey, ^uint32(0), MakeInodeID(InodeTypeFile, 1),
-		false, StateID{},
-	); status != NFS4_OK {
-		t.Fatal(Nfsstat4Name(status))
+func (op *openOwnerOperation) abort() {
+	op.finished = true
+	op.store.releaseOwner(op.owner)
+}
+
+func assertOpenStateIndex(t *testing.T, store *openStateStore) {
+	t.Helper()
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	indexed := 0
+	for key, owner := range store.owners {
+		for fileID, state := range owner.states {
+			indexed++
+			if state.owner != key {
+				t.Fatalf("owner index key = %#v, state owner = %#v",
+					key, state.owner)
+			}
+			if state.fileID != fileID {
+				t.Fatalf("owner index file = %v, state file = %v",
+					fileID, state.fileID)
+			}
+			if store.states[state.id] != state {
+				t.Fatalf("owner index state %x is absent from stateid index",
+					state.id)
+			}
+		}
 	}
-	if got := store.owners[ownerKey].nextSeq; got != 1 {
-		t.Fatalf("next seqid = %d, want 1", got)
+	if indexed != len(store.states) {
+		t.Fatalf("owner index has %d states, stateid index has %d",
+			indexed, len(store.states))
+	}
+	for id, state := range store.states {
+		owner := store.owners[state.owner]
+		if owner == nil || owner.states[state.fileID] != state {
+			t.Fatalf("stateid index state %x is absent from owner index", id)
+		}
 	}
 }
 

--- a/go/nfsd/open_state_test.go
+++ b/go/nfsd/open_state_test.go
@@ -4,19 +4,54 @@
 
 package main
 
+import "testing"
+
 // These adapters keep focused store tests concise. Production operations use
 // start*/finish* directly so owner locks cover their filesystem side effects.
+
+func TestOpenOwnerSeqidWrapsToOne(t *testing.T) {
+	store := newOpenStateStore()
+	ownerKey := openOwnerKey{clientID: 1, owner: "owner"}
+	if _, status := store.addOpen(
+		ownerKey, ^uint32(0), MakeInodeID(InodeTypeFile, 1),
+		false, StateID{},
+	); status != NFS4_OK {
+		t.Fatal(Nfsstat4Name(status))
+	}
+	if got := store.owners[ownerKey].nextSeq; got != 1 {
+		t.Fatalf("next seqid = %d, want 1", got)
+	}
+}
+
+func ownerOperationResult(
+	op *openOwnerOperation,
+	state openState,
+	response openOwnerResponse,
+	replay bool,
+	status uint32,
+	finish func(*openOwnerOperation) openOwnerResponse,
+) (openState, bool, uint32) {
+	if op == nil {
+		if replay {
+			return response.state, true, response.status
+		}
+		return state, false, status
+	}
+	if finish == nil {
+		op.abort()
+		return state, false, status
+	}
+	response = finish(op)
+	return response.state, false, response.status
+}
 
 func (os *openStateStore) beginOpen(
 	key openOwnerKey,
 	seq uint32,
 ) (openState, bool, uint32) {
 	op, response, replay, status := os.startOpen(key, seq)
-	if op != nil {
-		op.finished = true
-		os.releaseOwner(op.owner)
-	}
-	return response.state, replay, status
+	return ownerOperationResult(
+		op, openState{}, response, replay, status, nil)
 }
 
 func (os *openStateStore) addOpen(
@@ -27,14 +62,12 @@ func (os *openStateStore) addOpen(
 	id StateID,
 ) (openState, uint32) {
 	op, response, replay, status := os.startOpen(owner, seq)
-	if op == nil {
-		if replay {
-			return response.state, response.status
-		}
-		return openState{}, status
-	}
-	response = op.finishOpen(fileID, write, id, false)
-	return response.state, response.status
+	state, _, status := ownerOperationResult(
+		op, openState{}, response, replay, status,
+		func(op *openOwnerOperation) openOwnerResponse {
+			return op.finishOpen(fileID, write, id, false)
+		})
+	return state, status
 }
 
 func (os *openStateStore) confirm(
@@ -43,16 +76,14 @@ func (os *openStateStore) confirm(
 	fileID InodeID,
 	seq uint32,
 ) (openState, uint32) {
-	op, _, response, replay, status := os.startConfirm(
+	op, state, response, replay, status := os.startConfirm(
 		id, generation, fileID, seq)
-	if op == nil {
-		if replay {
-			return response.state, response.status
-		}
-		return openState{}, status
-	}
-	response = op.finishConfirm(id, generation, fileID)
-	return response.state, response.status
+	state, _, status = ownerOperationResult(
+		op, state, response, replay, status,
+		func(op *openOwnerOperation) openOwnerResponse {
+			return op.finishConfirm(id, generation, fileID)
+		})
+	return state, status
 }
 
 func (os *openStateStore) validateClose(
@@ -63,14 +94,7 @@ func (os *openStateStore) validateClose(
 ) (openState, bool, uint32) {
 	op, state, response, replay, status := os.startClose(
 		id, generation, fileID, seq)
-	if op != nil {
-		op.finished = true
-		os.releaseOwner(op.owner)
-	}
-	if replay {
-		return response.state, true, response.status
-	}
-	return state, false, status
+	return ownerOperationResult(op, state, response, replay, status, nil)
 }
 
 func (os *openStateStore) close(
@@ -78,39 +102,38 @@ func (os *openStateStore) close(
 	seq uint32,
 ) (openState, uint32) {
 	os.mu.Lock()
-	state := os.states[id]
-	if state == nil {
+	stored := os.states[id]
+	if stored == nil {
 		os.mu.Unlock()
 		return openState{}, NFS4ERR_BAD_STATEID
 	}
-	generation := state.generation
-	fileID := state.fileID
+	generation := stored.generation
+	fileID := stored.fileID
 	os.mu.Unlock()
 	op, _, response, replay, status := os.startClose(
 		id, generation, fileID, seq)
-	if op == nil {
-		if replay {
-			return response.state, response.status
-		}
-		return openState{}, status
-	}
-	response = op.finishClose(id, generation, fileID)
-	return response.state, response.status
+	state, _, status := ownerOperationResult(
+		op, *stored, response, replay, status,
+		func(op *openOwnerOperation) openOwnerResponse {
+			return op.finishClose(id, generation, fileID)
+		})
+	return state, status
 }
 
-func (os *openStateStore) closeRecovered(
-	id StateID,
+func addConfirmedOpen(
+	t *testing.T,
+	store *openStateStore,
+	owner openOwnerKey,
 	fileID InodeID,
-	generation uint32,
-	seq uint32,
 ) openState {
-	op, response, replay, status := os.startRecoveredClose(
-		id, fileID, generation, seq)
-	if op == nil {
-		if replay && status == NFS4_OK {
-			return response.state
-		}
-		return openState{}
+	t.Helper()
+	state, status := store.addOpen(owner, 1, fileID, false, StateID{})
+	if status != NFS4_OK {
+		t.Fatalf("OPEN status = %s", Nfsstat4Name(status))
 	}
-	return op.finish(NFS4_OK).state
+	confirmed, status := store.confirm(state.id, 1, fileID, 2)
+	if status != NFS4_OK {
+		t.Fatalf("OPEN_CONFIRM status = %s", Nfsstat4Name(status))
+	}
+	return confirmed
 }

--- a/go/nfsd/open_state_test.go
+++ b/go/nfsd/open_state_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+// These adapters keep focused store tests concise. Production operations use
+// start*/finish* directly so owner locks cover their filesystem side effects.
+
+func (os *openStateStore) beginOpen(
+	key openOwnerKey,
+	seq uint32,
+) (openState, bool, uint32) {
+	op, response, replay, status := os.startOpen(key, seq)
+	if op != nil {
+		op.finished = true
+		os.releaseOwner(op.owner)
+	}
+	return response.state, replay, status
+}
+
+func (os *openStateStore) addOpen(
+	owner openOwnerKey,
+	seq uint32,
+	fileID InodeID,
+	write bool,
+	id StateID,
+) (openState, uint32) {
+	op, response, replay, status := os.startOpen(owner, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
+	}
+	response = op.finishOpen(fileID, write, id, false)
+	return response.state, response.status
+}
+
+func (os *openStateStore) confirm(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+	seq uint32,
+) (openState, uint32) {
+	op, _, response, replay, status := os.startConfirm(
+		id, generation, fileID, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
+	}
+	response = op.finishConfirm(id, generation, fileID)
+	return response.state, response.status
+}
+
+func (os *openStateStore) validateClose(
+	id StateID,
+	generation uint32,
+	fileID InodeID,
+	seq uint32,
+) (openState, bool, uint32) {
+	op, state, response, replay, status := os.startClose(
+		id, generation, fileID, seq)
+	if op != nil {
+		op.finished = true
+		os.releaseOwner(op.owner)
+	}
+	if replay {
+		return response.state, true, response.status
+	}
+	return state, false, status
+}
+
+func (os *openStateStore) close(
+	id StateID,
+	seq uint32,
+) (openState, uint32) {
+	os.mu.Lock()
+	state := os.states[id]
+	if state == nil {
+		os.mu.Unlock()
+		return openState{}, NFS4ERR_BAD_STATEID
+	}
+	generation := state.generation
+	fileID := state.fileID
+	os.mu.Unlock()
+	op, _, response, replay, status := os.startClose(
+		id, generation, fileID, seq)
+	if op == nil {
+		if replay {
+			return response.state, response.status
+		}
+		return openState{}, status
+	}
+	response = op.finishClose(id, generation, fileID)
+	return response.state, response.status
+}
+
+func (os *openStateStore) closeRecovered(
+	id StateID,
+	fileID InodeID,
+	generation uint32,
+	seq uint32,
+) openState {
+	op, response, replay, status := os.startRecoveredClose(
+		id, fileID, generation, seq)
+	if op == nil {
+		if replay && status == NFS4_OK {
+			return response.state
+		}
+		return openState{}
+	}
+	return op.finish(NFS4_OK).state
+}

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -59,6 +59,36 @@ func requireRegularFile(id InodeID) uint32 {
 	}
 }
 
+// lookupOpenOrRecover accepts normal in-memory open state. After a restart,
+// the staging sidecar is the durable proof that this stateid is the confirmed
+// write-open for this transient file.
+func (s *Server) lookupOpenOrRecover(
+	stateid Stateid4,
+	fileID InodeID,
+) (openState, uint32) {
+	state, status := s.opens.lookup(
+		extractStateID(stateid),
+		stateid.Seqid(),
+		fileID,
+	)
+	if status == NFS4_OK {
+		return state, status
+	}
+
+	id := extractStateID(stateid)
+	meta, hasMeta := s.stagingStore.GetMeta(fileID)
+	if !hasMeta || meta.NFSStateID != id || !s.opens.canRecover(id) {
+		return openState{}, status
+	}
+	return openState{
+		id:         id,
+		fileID:     fileID,
+		write:      true,
+		generation: stateid.Seqid(),
+		confirmed:  true,
+	}, NFS4_OK
+}
+
 func (s *Server) opAccess(args ACCESS4args, st *compoundState, w *COMPOUND4resWriter) uint32 {
 	if !st.currentIDSet {
 		ew := w.AppendResarray_Access()
@@ -847,11 +877,7 @@ func (s *Server) opRead(args READ4args, st *compoundState, w *COMPOUND4resWriter
 	}
 
 	if !isSpecialStateID(args.Stateid()) {
-		_, status := s.opens.lookup(
-			extractStateID(args.Stateid()),
-			args.Stateid().Seqid(),
-			st.currentID,
-		)
+		_, status := s.lookupOpenOrRecover(args.Stateid(), st.currentID)
 		if status != NFS4_OK {
 			ew := w.AppendResarray_Read()
 			ew.SetValue_Default(status)
@@ -1241,8 +1267,7 @@ func (s *Server) opRename(args RENAME4args, st *compoundState, w *COMPOUND4resWr
 }
 
 func (s *Server) opRenew(args RENEW4args, w *COMPOUND4resWriter) uint32 {
-	// Client-wide lease tracking is implemented by the durable client store
-	// in pynfs4. Pynfs3 keeps only process-local open-owner sequencing state.
+	// This server keeps no client-wide lease state, so renewal is a no-op.
 	_ = args.Clientid()
 	r := w.AppendResarray_Renew()
 	r.SetStatus(NFS4_OK)
@@ -1430,11 +1455,8 @@ func (s *Server) opSetattr(args SETATTR4args, st *compoundState, w *COMPOUND4res
 
 	if newSize != nil {
 		if !isSpecialStateID(args.Stateid()) {
-			state, status := s.opens.lookup(
-				extractStateID(args.Stateid()),
-				args.Stateid().Seqid(),
-				st.currentID,
-			)
+			state, status := s.lookupOpenOrRecover(
+				args.Stateid(), st.currentID)
 			if status != NFS4_OK {
 				return setattrReply(status, [2]uint32{})
 			}
@@ -1544,11 +1566,7 @@ func (s *Server) opWrite(args WRITE4args, st *compoundState, w *COMPOUND4resWrit
 	}
 
 	if !isSpecialStateID(args.Stateid()) {
-		state, status := s.opens.lookup(
-			extractStateID(args.Stateid()),
-			args.Stateid().Seqid(),
-			st.currentID,
-		)
+		state, status := s.lookupOpenOrRecover(args.Stateid(), st.currentID)
 		if status != NFS4_OK {
 			ew := w.AppendResarray_Write()
 			ew.SetValue_Default(status)

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -121,7 +121,7 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 
 	sid := extractStateID(args.OpenStateid())
 	meta, hasMeta := s.stagingStore.GetMeta(st.currentID)
-	op, _, response, replay, status := s.opens.startClose(
+	op, state, response, replay, status := s.opens.startClose(
 		sid,
 		args.OpenStateid().Seqid(),
 		st.currentID,
@@ -160,6 +160,11 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 		return writeCloseResponse(w, response)
 	}
 
+	// GetMeta before startClose is only a hint for restart recovery. Re-read
+	// it after taking the owner operation so a waiting CLOSE cannot act on
+	// staging removed by the operation ahead of it.
+	meta, hasMeta = s.stagingStore.GetMeta(st.currentID)
+
 	// Check if there's a staging file for the current filehandle.
 	if hasMeta {
 		// First CLOSE for a write-open: link the transient file.
@@ -186,10 +191,17 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 			return fail(status)
 		}
 	} else {
-		// No staging: either a read-close or a write CLOSE after staging was
-		// lost. A successful write CLOSE replay is served from the owner cache
-		// before reaching this path.
-		if _, err := s.fs.Stat(st.currentID); err != nil {
+		// Read CLOSE does not need the file to remain linked. A write CLOSE
+		// without staging has lost the data it was meant to publish.
+		if op != nil && state.write {
+			s.log.Error("close: write staging missing",
+				"file_id", st.currentID, "stateid", sid)
+			response = op.finishExpiredClose()
+			return writeCloseResponse(w, response)
+		}
+		if recovered != nil {
+			s.log.Error("close: recovered write staging missing",
+				"file_id", st.currentID, "stateid", sid)
 			return fail(NFS4ERR_EXPIRED)
 		}
 	}
@@ -612,6 +624,9 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		return writeOpenError(w, status)
 	}
 	defer op.finishServerFaultIfNeeded()
+	for _, fileID := range op.abandoned {
+		s.stagingStore.Remove(fileID)
+	}
 	fail := func(status uint32) uint32 {
 		response = op.finishError(status)
 		return writeOpenResponse(w, st, response)
@@ -821,7 +836,8 @@ func writeOpenConfirmResponse(
 }
 
 func (s *Server) opOpenDowngrade(st *compoundState, w *COMPOUND4resWriter) uint32 {
-	// No persistent open state — downgrade is a no-op.
+	// Existing immutable files cannot be upgraded from read to write, and no
+	// supported client has required a downgrade.
 	ew := w.AppendResarray_OpenDowngrade()
 	ew.SetValue_Default(NFS4ERR_NOTSUPP)
 	w.Resume(ew.Finish())

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -90,9 +90,31 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 	}
 
 	sid := extractStateID(args.OpenStateid())
+	meta, hasMeta := s.stagingStore.GetMeta(st.currentID)
+	openState, replay, status := s.opens.validateClose(
+		sid,
+		args.OpenStateid().Seqid(),
+		st.currentID,
+		args.Seqid(),
+	)
+	recovered := status != NFS4_OK && hasMeta &&
+		sid == meta.NFSStateID && s.opens.canRecover(sid)
+	if status != NFS4_OK && !recovered {
+		ew := w.AppendResarray_Close()
+		ew.SetValue_Default(status)
+		w.Resume(ew.Finish())
+		return status
+	}
+	if replay {
+		ew := w.AppendResarray_Close()
+		stid := ew.SetValue_Nfs4Ok()
+		stid.SetSeqid(openState.generation)
+		writeStateID(stid, sid)
+		w.Resume(ew.Finish())
+		return NFS4_OK
+	}
 
 	// Check if there's a staging file for the current filehandle.
-	meta, hasMeta := s.stagingStore.GetMeta(st.currentID)
 	if hasMeta {
 		// First CLOSE for a write-open: link the transient file.
 		if sid != meta.NFSStateID {
@@ -137,9 +159,25 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 		}
 	}
 
+	if recovered {
+		openState = s.opens.closeRecovered(
+			sid,
+			st.currentID,
+			args.OpenStateid().Seqid(),
+			args.Seqid(),
+		)
+	} else {
+		openState, status = s.opens.close(sid, args.Seqid())
+		if status != NFS4_OK {
+			ew := w.AppendResarray_Close()
+			ew.SetValue_Default(status)
+			w.Resume(ew.Finish())
+			return status
+		}
+	}
 	ew := w.AppendResarray_Close()
 	stid := ew.SetValue_Nfs4Ok()
-	stid.SetSeqid(args.OpenStateid().Seqid() + 1)
+	stid.SetSeqid(openState.generation)
 	writeStateID(stid, sid)
 	w.Resume(ew.Finish())
 	return NFS4_OK
@@ -524,6 +562,23 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 	claimType := args.ClaimType()
 	owner := args.Owner()
 	clientID := owner.Clientid()
+	ownerKey := openOwnerKey{
+		clientID: clientID,
+		owner:    string(owner.Owner()),
+	}
+	replayState, replay, status := s.opens.beginOpen(ownerKey, args.Seqid())
+	if status != NFS4_OK {
+		ew := w.AppendResarray_Open()
+		ew.SetValue_Default(status)
+		w.Resume(ew.Finish())
+		return status
+	}
+	if replay {
+		st.currentID = replayState.fileID
+		st.currentIDSet = true
+		writeOpenResponse(w, replayState, false)
+		return NFS4_OK
+	}
 
 	var targetID InodeID
 	var nfsSID StateID
@@ -583,7 +638,7 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 					return s.errToNFS(err)
 				}
 				// Generate a random NFS stateid and create staging with metadata.
-				nfsSID = newNFSStateID()
+				nfsSID = s.opens.newStateID()
 				meta := StagingMeta{
 					DirID:      dirID,
 					FileName:   fileName,
@@ -648,20 +703,42 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		return status
 	}
 
-	// For read opens, derive a deterministic stateid from the file and client.
-	if !created {
-		nfsSID = deriveReadStateID(targetID, clientID)
+	state, status := s.opens.addOpen(
+		ownerKey,
+		args.Seqid(),
+		targetID,
+		access&OPEN4_SHARE_ACCESS_WRITE != 0,
+		nfsSID,
+	)
+	if status != NFS4_OK {
+		if created {
+			s.stagingStore.Remove(targetID)
+		}
+		ew := w.AppendResarray_Open()
+		ew.SetValue_Default(status)
+		w.Resume(ew.Finish())
+		return status
 	}
+	nfsSID = state.id
 
 	st.currentID = targetID
 	st.currentIDSet = true
 
+	writeOpenResponse(w, state, created)
+	return NFS4_OK
+}
+
+func writeOpenResponse(
+	w *COMPOUND4resWriter,
+	state openState,
+	created bool,
+) {
 	ew := w.AppendResarray_Open()
 	okW := ew.SetValue_Nfs4Ok()
 
 	stid := okW.Stateid()
-	stid.SetSeqid(1)
-	writeStateID(stid, nfsSID)
+	stid.SetSeqid(state.generation)
+	writeStateID(stid, state.id)
 
 	cinfo := okW.Cinfo()
 	cinfo.SetAtomic(TRUE)
@@ -674,7 +751,7 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		cinfo.SetAfter(now)
 	}
 
-	okW.SetRflags(OPEN4_RESULT_LOCKTYPE_POSIX)
+	okW.SetRflags(OPEN4_RESULT_LOCKTYPE_POSIX | OPEN4_RESULT_CONFIRM)
 
 	bmW := okW.StartAttrset()
 	buf := bmW.Finish()
@@ -685,18 +762,6 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 	buf = okW.Finish()
 	ew.Resume(buf)
 	w.Resume(ew.Finish())
-	return NFS4_OK
-}
-
-// deriveReadStateID produces a deterministic stateid for read opens.
-// The stateid encodes the InodeID and a hash of the client ID, so any
-// server instance can recompute it without persistent state.
-func deriveReadStateID(fileID InodeID, clientID uint64) StateID {
-	var sid StateID
-	binary.BigEndian.PutUint64(sid[0:8], uint64(fileID))
-	// Mix in the client ID for basic validation.
-	binary.BigEndian.PutUint32(sid[8:12], uint32(clientID^(clientID>>32)))
-	return sid
 }
 
 func (s *Server) opOpenConfirm(args OPENCONFIRM4args, st *compoundState, w *COMPOUND4resWriter) uint32 {
@@ -708,14 +773,22 @@ func (s *Server) opOpenConfirm(args OPENCONFIRM4args, st *compoundState, w *COMP
 	}
 
 	sid := extractStateID(args.OpenStateid())
-	seqid := args.OpenStateid().Seqid()
-
-	// No persistent open state to confirm — just echo the stateid
-	// with an incremented seqid.
+	state, status := s.opens.confirm(
+		sid,
+		args.OpenStateid().Seqid(),
+		st.currentID,
+		args.Seqid(),
+	)
+	if status != NFS4_OK {
+		ew := w.AppendResarray_OpenConfirm()
+		ew.SetValue_Default(status)
+		w.Resume(ew.Finish())
+		return status
+	}
 	ew := w.AppendResarray_OpenConfirm()
 	ok := ew.SetValue_Nfs4Ok()
 	stid := ok.OpenStateid()
-	stid.SetSeqid(seqid + 1)
+	stid.SetSeqid(state.generation)
 	writeStateID(stid, sid)
 	w.Resume(ew.Finish())
 	return NFS4_OK
@@ -775,6 +848,20 @@ func (s *Server) opRead(args READ4args, st *compoundState, w *COMPOUND4resWriter
 		ew.SetValue_Default(status)
 		w.Resume(ew.Finish())
 		return status
+	}
+
+	if !isSpecialStateID(args.Stateid()) {
+		_, status := s.opens.lookup(
+			extractStateID(args.Stateid()),
+			args.Stateid().Seqid(),
+			st.currentID,
+		)
+		if status != NFS4_OK {
+			ew := w.AppendResarray_Read()
+			ew.SetValue_Default(status)
+			w.Resume(ew.Finish())
+			return status
+		}
 	}
 
 	// Check if we should read from a staging buffer.
@@ -1345,6 +1432,19 @@ func (s *Server) opSetattr(args SETATTR4args, st *compoundState, w *COMPOUND4res
 	}
 
 	if newSize != nil {
+		if !isSpecialStateID(args.Stateid()) {
+			state, status := s.opens.lookup(
+				extractStateID(args.Stateid()),
+				args.Stateid().Seqid(),
+				st.currentID,
+			)
+			if status != NFS4_OK {
+				return setattrReply(status, [2]uint32{})
+			}
+			if !state.write {
+				return setattrReply(NFS4ERR_OPENMODE, [2]uint32{})
+			}
+		}
 		sf := s.stagingStore.Get(st.currentID)
 		if sf == nil {
 			return setattrReply(NFS4ERR_BAD_STATEID, [2]uint32{})
@@ -1396,11 +1496,14 @@ func (s *Server) opSetclientid(args SETCLIENTID4args, w *COMPOUND4resWriter) uin
 
 func (s *Server) opSetclientidConfirm(args SETCLIENTIDCONFIRM4args, w *COMPOUND4resWriter) uint32 {
 	clid := args.Clientid()
-	_, err := s.clients.ConfirmClientID(clid)
+	oldClientID, err := s.clients.ConfirmClientID(clid)
 	if err != nil {
 		r := w.AppendResarray_SetclientidConfirm()
 		r.SetStatus(nfsErrCode(err))
 		return nfsErrCode(err)
+	}
+	for _, fileID := range s.opens.purgeClient(oldClientID) {
+		s.stagingStore.Remove(fileID)
 	}
 	r := w.AppendResarray_SetclientidConfirm()
 	r.SetStatus(NFS4_OK)
@@ -1441,6 +1544,26 @@ func (s *Server) opWrite(args WRITE4args, st *compoundState, w *COMPOUND4resWrit
 		ew.SetValue_Default(status)
 		w.Resume(ew.Finish())
 		return status
+	}
+
+	if !isSpecialStateID(args.Stateid()) {
+		state, status := s.opens.lookup(
+			extractStateID(args.Stateid()),
+			args.Stateid().Seqid(),
+			st.currentID,
+		)
+		if status != NFS4_OK {
+			ew := w.AppendResarray_Write()
+			ew.SetValue_Default(status)
+			w.Resume(ew.Finish())
+			return status
+		}
+		if !state.write {
+			ew := w.AppendResarray_Write()
+			ew.SetValue_Default(NFS4ERR_OPENMODE)
+			w.Resume(ew.Finish())
+			return NFS4ERR_OPENMODE
+		}
 	}
 
 	// Find the staging buffer for this file.

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -91,37 +91,50 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 
 	sid := extractStateID(args.OpenStateid())
 	meta, hasMeta := s.stagingStore.GetMeta(st.currentID)
-	openState, replay, status := s.opens.validateClose(
+	op, _, response, replay, status := s.opens.startClose(
 		sid,
 		args.OpenStateid().Seqid(),
 		st.currentID,
 		args.Seqid(),
 	)
-	recovered := status != NFS4_OK && hasMeta &&
-		sid == meta.NFSStateID && s.opens.canRecover(sid)
-	if status != NFS4_OK && !recovered {
+	var recovered *recoveredCloseOperation
+	if op == nil && !replay && status != NFS4_OK &&
+		hasMeta && sid == meta.NFSStateID && s.opens.canRecover(sid) {
+		recovered, response, replay, status = s.opens.startRecoveredClose(
+			sid,
+			st.currentID,
+			args.OpenStateid().Seqid(),
+			args.Seqid(),
+		)
+	}
+	if op == nil && recovered == nil {
+		if replay {
+			return writeCloseResponse(w, response)
+		}
 		ew := w.AppendResarray_Close()
 		ew.SetValue_Default(status)
 		w.Resume(ew.Finish())
 		return status
 	}
-	if replay {
-		ew := w.AppendResarray_Close()
-		stid := ew.SetValue_Nfs4Ok()
-		stid.SetSeqid(openState.generation)
-		writeStateID(stid, sid)
-		w.Resume(ew.Finish())
-		return NFS4_OK
+	if op != nil {
+		defer op.finishServerFaultIfNeeded()
+	} else {
+		defer recovered.finishServerFaultIfNeeded()
+	}
+	fail := func(status uint32) uint32 {
+		if op != nil {
+			response = op.finishError(status)
+		} else {
+			response = recovered.finish(status)
+		}
+		return writeCloseResponse(w, response)
 	}
 
 	// Check if there's a staging file for the current filehandle.
 	if hasMeta {
 		// First CLOSE for a write-open: link the transient file.
 		if sid != meta.NFSStateID {
-			ew := w.AppendResarray_Close()
-			ew.SetValue_Default(NFS4ERR_BAD_STATEID)
-			w.Resume(ew.Finish())
-			return NFS4ERR_BAD_STATEID
+			return fail(NFS4ERR_BAD_STATEID)
 		}
 		sf := s.stagingStore.Get(st.currentID)
 		if sf == nil {
@@ -140,45 +153,42 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 		if linkErr != nil {
 			status := s.errToNFS(linkErr)
 			s.log.Error("close: link file", "err", linkErr, "status", Nfsstat4Name(status))
-			ew := w.AppendResarray_Close()
-			ew.SetValue_Default(status)
-			w.Resume(ew.Finish())
-			return status
+			return fail(status)
 		}
 	} else {
-		// No staging: either a read-close or a replay of a write-close.
-		// Check if the file still exists. For read opens the file is
-		// immutable and always exists. For write-close replays the file
-		// exists if LinkFile succeeded previously. If the transient was
-		// GC'd without being linked, Stat fails and we report expired.
+		// No staging: either a read-close or a write CLOSE after staging was
+		// lost. A successful write CLOSE replay is served from the owner cache
+		// before reaching this path.
 		if _, err := s.fs.Stat(st.currentID); err != nil {
-			ew := w.AppendResarray_Close()
-			ew.SetValue_Default(NFS4ERR_EXPIRED)
-			w.Resume(ew.Finish())
-			return NFS4ERR_EXPIRED
+			return fail(NFS4ERR_EXPIRED)
 		}
 	}
 
-	if recovered {
-		openState = s.opens.closeRecovered(
+	if op != nil {
+		response = op.finishClose(
 			sid,
-			st.currentID,
 			args.OpenStateid().Seqid(),
-			args.Seqid(),
+			st.currentID,
 		)
 	} else {
-		openState, status = s.opens.close(sid, args.Seqid())
-		if status != NFS4_OK {
-			ew := w.AppendResarray_Close()
-			ew.SetValue_Default(status)
-			w.Resume(ew.Finish())
-			return status
-		}
+		response = recovered.finish(NFS4_OK)
 	}
+	return writeCloseResponse(w, response)
+}
+
+func writeCloseResponse(
+	w *COMPOUND4resWriter,
+	response openOwnerResponse,
+) uint32 {
 	ew := w.AppendResarray_Close()
+	if response.status != NFS4_OK {
+		ew.SetValue_Default(response.status)
+		w.Resume(ew.Finish())
+		return response.status
+	}
 	stid := ew.SetValue_Nfs4Ok()
-	stid.SetSeqid(openState.generation)
-	writeStateID(stid, sid)
+	stid.SetSeqid(response.state.generation)
+	writeStateID(stid, response.state.id)
 	w.Resume(ew.Finish())
 	return NFS4_OK
 }
@@ -549,35 +559,38 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		return NFS4ERR_NOFILEHANDLE
 	}
 
-	// Reject all writes if read-only (no staging directory configured).
-	access := args.ShareAccess()
-	if s.stagingStore.ReadOnly() && access&OPEN4_SHARE_ACCESS_WRITE != 0 {
-		ew := w.AppendResarray_Open()
-		ew.SetValue_Default(NFS4ERR_ROFS)
-		w.Resume(ew.Finish())
-		return NFS4ERR_ROFS
-	}
-
 	claim := args.Claim()
 	claimType := args.ClaimType()
 	owner := args.Owner()
 	clientID := owner.Clientid()
+	if !s.clients.IsConfirmed(clientID) {
+		ew := w.AppendResarray_Open()
+		ew.SetValue_Default(NFS4ERR_STALE_CLIENTID)
+		w.Resume(ew.Finish())
+		return NFS4ERR_STALE_CLIENTID
+	}
 	ownerKey := openOwnerKey{
 		clientID: clientID,
 		owner:    string(owner.Owner()),
 	}
-	replayState, replay, status := s.opens.beginOpen(ownerKey, args.Seqid())
-	if status != NFS4_OK {
-		ew := w.AppendResarray_Open()
-		ew.SetValue_Default(status)
-		w.Resume(ew.Finish())
-		return status
-	}
+	op, response, replay, status := s.opens.startOpen(
+		ownerKey, args.Seqid())
 	if replay {
-		st.currentID = replayState.fileID
-		st.currentIDSet = true
-		writeOpenResponse(w, replayState, false)
-		return NFS4_OK
+		return writeOpenResponse(w, st, response)
+	}
+	if op == nil {
+		return writeOpenError(w, status)
+	}
+	defer op.finishServerFaultIfNeeded()
+	fail := func(status uint32) uint32 {
+		response = op.finishError(status)
+		return writeOpenResponse(w, st, response)
+	}
+
+	// Failures from this point participate in the open-owner sequence.
+	access := args.ShareAccess()
+	if s.stagingStore.ReadOnly() && access&OPEN4_SHARE_ACCESS_WRITE != 0 {
+		return fail(NFS4ERR_ROFS)
 	}
 
 	var targetID InodeID
@@ -588,17 +601,11 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 	case CLAIM_NULL:
 		dirID := st.currentID
 		if status := requireDirectory(dirID); status != NFS4_OK {
-			ew := w.AppendResarray_Open()
-			ew.SetValue_Default(status)
-			w.Resume(ew.Finish())
-			return status
+			return fail(status)
 		}
 		fileName, status := toTernFSName(claim.AsNull().Data())
 		if status != NFS4_OK {
-			ew := w.AppendResarray_Open()
-			ew.SetValue_Default(status)
-			w.Resume(ew.Finish())
-			return status
+			return fail(status)
 		}
 
 		// Check if this is a create.
@@ -607,10 +614,7 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 			// EXCLUSIVE4 not supported — clients should fall back
 			// to GUARDED4 or UNCHECKED4.
 			if createHow.Disc() == EXCLUSIVE4 {
-				ew := w.AppendResarray_Open()
-				ew.SetValue_Default(NFS4ERR_NOTSUPP)
-				w.Resume(ew.Finish())
-				return NFS4ERR_NOTSUPP
+				return fail(NFS4ERR_NOTSUPP)
 			}
 			var createAttrs Fattr4
 			switch createHow.Disc() {
@@ -620,10 +624,7 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 				createAttrs = createHow.Value().AsGuarded4()
 			}
 			if status := validateCreateAttrs(createAttrs); status != NFS4_OK {
-				ew := w.AppendResarray_Open()
-				ew.SetValue_Default(status)
-				w.Resume(ew.Finish())
-				return status
+				return fail(status)
 			}
 			// Try lookup first.
 			id, err := s.fs.Lookup(dirID, fileName)
@@ -632,10 +633,7 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 				var fileCookie Cookie
 				id, fileCookie, err = s.fs.ConstructFile(dirID)
 				if err != nil {
-					ew := w.AppendResarray_Open()
-					ew.SetValue_Default(s.errToNFS(err))
-					w.Resume(ew.Finish())
-					return s.errToNFS(err)
+					return fail(s.errToNFS(err))
 				}
 				// Generate a random NFS stateid and create staging with metadata.
 				nfsSID = s.opens.newStateID()
@@ -647,27 +645,18 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 				}
 				if _, sfErr := s.stagingStore.Create(id, meta); sfErr != nil {
 					s.log.Error("staging create error", "err", sfErr)
-					ew := w.AppendResarray_Open()
-					ew.SetValue_Default(NFS4ERR_IO)
-					w.Resume(ew.Finish())
-					return NFS4ERR_IO
+					return fail(NFS4ERR_IO)
 				}
 				created = true
 			} else if createHow.Disc() == GUARDED4 {
-				ew := w.AppendResarray_Open()
-				ew.SetValue_Default(NFS4ERR_EXIST)
-				w.Resume(ew.Finish())
-				return NFS4ERR_EXIST
+				return fail(NFS4ERR_EXIST)
 			}
 			targetID = id
 		} else {
 			id, err := s.fs.Lookup(dirID, fileName)
 			if err != nil {
-				ew := w.AppendResarray_Open()
 				status := s.errToNFS(err)
-				ew.SetValue_Default(status)
-				w.Resume(ew.Finish())
-				return status
+				return fail(status)
 			}
 			targetID = id
 		}
@@ -675,65 +664,45 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		// Files are immutable: reject write access to existing files.
 		// To replace a file, clients must remove + create.
 		if !created && access&OPEN4_SHARE_ACCESS_WRITE != 0 {
-			ew := w.AppendResarray_Open()
-			ew.SetValue_Default(NFS4ERR_PERM)
-			w.Resume(ew.Finish())
-			return NFS4ERR_PERM
+			return fail(NFS4ERR_PERM)
 		}
 	case CLAIM_PREVIOUS:
 		// No grace period — there is no lock/open state to reclaim.
-		ew := w.AppendResarray_Open()
-		ew.SetValue_Default(NFS4ERR_NO_GRACE)
-		w.Resume(ew.Finish())
-		return NFS4ERR_NO_GRACE
+		return fail(NFS4ERR_NO_GRACE)
 	default:
-		ew := w.AppendResarray_Open()
-		ew.SetValue_Default(NFS4ERR_NOTSUPP)
-		w.Resume(ew.Finish())
-		return NFS4ERR_NOTSUPP
+		return fail(NFS4ERR_NOTSUPP)
 	}
 
 	if status := requireRegularFile(targetID); status != NFS4_OK {
-		ew := w.AppendResarray_Open()
 		if targetID.Type() == InodeTypeSymlink {
 			status = NFS4ERR_SYMLINK
 		}
-		ew.SetValue_Default(status)
-		w.Resume(ew.Finish())
-		return status
+		return fail(status)
 	}
 
-	state, status := s.opens.addOpen(
-		ownerKey,
-		args.Seqid(),
+	response = op.finishOpen(
 		targetID,
 		access&OPEN4_SHARE_ACCESS_WRITE != 0,
 		nfsSID,
+		created,
 	)
-	if status != NFS4_OK {
-		if created {
-			s.stagingStore.Remove(targetID)
-		}
-		ew := w.AppendResarray_Open()
-		ew.SetValue_Default(status)
-		w.Resume(ew.Finish())
-		return status
-	}
-	nfsSID = state.id
-
-	st.currentID = targetID
-	st.currentIDSet = true
-
-	writeOpenResponse(w, state, created)
-	return NFS4_OK
+	return writeOpenResponse(w, st, response)
 }
 
 func writeOpenResponse(
 	w *COMPOUND4resWriter,
-	state openState,
-	created bool,
-) {
+	st *compoundState,
+	response openOwnerResponse,
+) uint32 {
 	ew := w.AppendResarray_Open()
+	if response.status != NFS4_OK {
+		ew.SetValue_Default(response.status)
+		w.Resume(ew.Finish())
+		return response.status
+	}
+	state := response.state
+	st.currentID = state.fileID
+	st.currentIDSet = true
 	okW := ew.SetValue_Nfs4Ok()
 
 	stid := okW.Stateid()
@@ -742,16 +711,14 @@ func writeOpenResponse(
 
 	cinfo := okW.Cinfo()
 	cinfo.SetAtomic(TRUE)
-	now := uint64(time.Now().UnixNano())
-	if created {
-		cinfo.SetBefore(now - 1)
-		cinfo.SetAfter(now)
-	} else {
-		cinfo.SetBefore(now)
-		cinfo.SetAfter(now)
-	}
+	cinfo.SetBefore(response.changeBefore)
+	cinfo.SetAfter(response.changeAfter)
 
-	okW.SetRflags(OPEN4_RESULT_LOCKTYPE_POSIX | OPEN4_RESULT_CONFIRM)
+	rflags := uint32(OPEN4_RESULT_LOCKTYPE_POSIX)
+	if response.requireConfirm {
+		rflags |= OPEN4_RESULT_CONFIRM
+	}
+	okW.SetRflags(rflags)
 
 	bmW := okW.StartAttrset()
 	buf := bmW.Finish()
@@ -762,6 +729,14 @@ func writeOpenResponse(
 	buf = okW.Finish()
 	ew.Resume(buf)
 	w.Resume(ew.Finish())
+	return NFS4_OK
+}
+
+func writeOpenError(w *COMPOUND4resWriter, status uint32) uint32 {
+	ew := w.AppendResarray_Open()
+	ew.SetValue_Default(status)
+	w.Resume(ew.Finish())
+	return status
 }
 
 func (s *Server) opOpenConfirm(args OPENCONFIRM4args, st *compoundState, w *COMPOUND4resWriter) uint32 {
@@ -773,23 +748,44 @@ func (s *Server) opOpenConfirm(args OPENCONFIRM4args, st *compoundState, w *COMP
 	}
 
 	sid := extractStateID(args.OpenStateid())
-	state, status := s.opens.confirm(
+	op, _, response, replay, status := s.opens.startConfirm(
 		sid,
 		args.OpenStateid().Seqid(),
 		st.currentID,
 		args.Seqid(),
 	)
-	if status != NFS4_OK {
+	if replay {
+		return writeOpenConfirmResponse(w, response)
+	}
+	if op == nil {
 		ew := w.AppendResarray_OpenConfirm()
 		ew.SetValue_Default(status)
 		w.Resume(ew.Finish())
 		return status
 	}
+	defer op.finishServerFaultIfNeeded()
+	response = op.finishConfirm(
+		sid,
+		args.OpenStateid().Seqid(),
+		st.currentID,
+	)
+	return writeOpenConfirmResponse(w, response)
+}
+
+func writeOpenConfirmResponse(
+	w *COMPOUND4resWriter,
+	response openOwnerResponse,
+) uint32 {
 	ew := w.AppendResarray_OpenConfirm()
+	if response.status != NFS4_OK {
+		ew.SetValue_Default(response.status)
+		w.Resume(ew.Finish())
+		return response.status
+	}
 	ok := ew.SetValue_Nfs4Ok()
 	stid := ok.OpenStateid()
-	stid.SetSeqid(state.generation)
-	writeStateID(stid, sid)
+	stid.SetSeqid(response.state.generation)
+	writeStateID(stid, response.state.id)
 	w.Resume(ew.Finish())
 	return NFS4_OK
 }
@@ -1245,7 +1241,8 @@ func (s *Server) opRename(args RENAME4args, st *compoundState, w *COMPOUND4resWr
 }
 
 func (s *Server) opRenew(args RENEW4args, w *COMPOUND4resWriter) uint32 {
-	// No lease state — just accept the renewal.
+	// Client-wide lease tracking is implemented by the durable client store
+	// in pynfs4. Pynfs3 keeps only process-local open-owner sequencing state.
 	_ = args.Clientid()
 	r := w.AppendResarray_Renew()
 	r.SetStatus(NFS4_OK)

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -199,11 +199,6 @@ func (s *Server) opClose(args CLOSE4args, st *compoundState, w *COMPOUND4resWrit
 			response = op.finishExpiredClose()
 			return writeCloseResponse(w, response)
 		}
-		if recovered != nil {
-			s.log.Error("close: recovered write staging missing",
-				"file_id", st.currentID, "stateid", sid)
-			return fail(NFS4ERR_EXPIRED)
-		}
 	}
 
 	if op != nil {
@@ -614,6 +609,9 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 	ownerKey := openOwnerKey{
 		clientID: clientID,
 		owner:    string(owner.Owner()),
+	}
+	if s.beforeStartOpen != nil {
+		s.beforeStartOpen()
 	}
 	op, response, replay, status := s.opens.startOpen(
 		ownerKey, args.Seqid())

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -624,8 +624,10 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		return writeOpenError(w, status)
 	}
 	defer op.finishServerFaultIfNeeded()
-	for _, fileID := range op.abandoned {
-		s.stagingStore.Remove(fileID)
+	for _, state := range op.abandoned {
+		if state.write {
+			s.stagingStore.Remove(state.fileID)
+		}
 	}
 	fail := func(status uint32) uint32 {
 		response = op.finishError(status)

--- a/go/nfsd/ops.go
+++ b/go/nfsd/ops.go
@@ -610,9 +610,6 @@ func (s *Server) opOpen(args OPEN4args, st *compoundState, w *COMPOUND4resWriter
 		clientID: clientID,
 		owner:    string(owner.Owner()),
 	}
-	if s.beforeStartOpen != nil {
-		s.beforeStartOpen()
-	}
 	op, response, replay, status := s.opens.startOpen(
 		ownerKey, args.Seqid())
 	if replay {

--- a/go/nfsd/pynfs_unsupported.txt
+++ b/go/nfsd/pynfs_unsupported.txt
@@ -62,10 +62,10 @@ RPLY7
 RPLY8
 CLOSE9
 
-# OPEN_DOWNGRADE is not implemented because nfsd does not retain the
-# open share state needed to reduce an existing open. Keep the whole
-# operation together here rather than reporting NFS4ERR_NOTSUPP as ten
-# distinct protocol failures.
+# OPEN_DOWNGRADE is not implemented. Existing immutable files cannot be
+# upgraded from read to write, and no supported client has required a
+# downgrade. Keep the whole operation together here rather than reporting
+# NFS4ERR_NOTSUPP as ten distinct protocol failures.
 OPDG1
 OPDG2
 OPDG3

--- a/go/nfsd/server.go
+++ b/go/nfsd/server.go
@@ -35,6 +35,7 @@ func peekCompoundHeader(body []byte) (tag []byte, minor uint32, ok bool) {
 type Server struct {
 	fs            TernVFS
 	clients       *ClientStore
+	opens         *openStateStore
 	stagingStore  StagingStore
 	writeVerifier [8]byte       // random per server instance, changes on restart
 	idleTimeout   time.Duration // connection idle timeout
@@ -54,6 +55,7 @@ func NewServer(fs TernVFS, stagingStore StagingStore, logger *slog.Logger) (*Ser
 	s := &Server{
 		fs:            fs,
 		clients:       clients,
+		opens:         newOpenStateStore(),
 		stagingStore:  stagingStore,
 		writeVerifier: verf,
 		idleTimeout:   5 * time.Minute,

--- a/go/nfsd/server.go
+++ b/go/nfsd/server.go
@@ -40,6 +40,8 @@ type Server struct {
 	writeVerifier [8]byte       // random per server instance, changes on restart
 	idleTimeout   time.Duration // connection idle timeout
 	log           *slog.Logger
+
+	beforeStartOpen func()
 }
 
 func NewServer(fs TernVFS, stagingStore StagingStore, logger *slog.Logger) (*Server, error) {

--- a/go/nfsd/server.go
+++ b/go/nfsd/server.go
@@ -40,8 +40,6 @@ type Server struct {
 	writeVerifier [8]byte       // random per server instance, changes on restart
 	idleTimeout   time.Duration // connection idle timeout
 	log           *slog.Logger
-
-	beforeStartOpen func()
 }
 
 func NewServer(fs TernVFS, stagingStore StagingStore, logger *slog.Logger) (*Server, error) {

--- a/go/nfsd/staging.go
+++ b/go/nfsd/staging.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -18,9 +17,9 @@ import (
 )
 
 // StagingMeta holds metadata for an in-progress write, persisted in a
-// sidecar file alongside the staging data. This is the only persistent
-// record of an NFS write-open; the NFS server derives open stateids from
-// the NFSStateID stored here rather than keeping separate open state.
+// sidecar file alongside the staging data. NFSStateID ties the persistent
+// staging record to the server's in-memory open state and permits a recovered
+// staging file to complete CLOSE after an nfsd restart.
 type StagingMeta struct {
 	DirID      InodeID // directory to link the file into on CLOSE
 	FileName   string  // name in directory
@@ -337,11 +336,4 @@ func loadStagingMeta(path string) (StagingMeta, error) {
 	}
 	meta.FileName = string(data[30 : 30+nameLen])
 	return meta, nil
-}
-
-// newNFSStateID generates a random 12-byte NFS state ID for write opens.
-func newNFSStateID() StateID {
-	var sid StateID
-	rand.Read(sid[:])
-	return sid
 }

--- a/go/nfsd/state.go
+++ b/go/nfsd/state.go
@@ -7,6 +7,17 @@ package main
 // StateID is the 12-byte "other" field of an NFSv4 stateid4.
 type StateID [12]byte
 
+func isSpecialStateID(stateid Stateid4) bool {
+	seqid := stateid.Seqid()
+	allZero := seqid == 0
+	allOne := seqid == ^uint32(0)
+	for i := 0; i < 12; i++ {
+		allZero = allZero && stateid.Other(i) == 0
+		allOne = allOne && stateid.Other(i) == 0xff
+	}
+	return allZero || allOne
+}
+
 // nfsError is a simple error type that carries an NFS status code.
 type nfsError uint32
 


### PR DESCRIPTION
pynfs CLOSE3/5/6 and OPCF1/4/5/6 showed that CLOSE and OPEN_CONFIRM accepted bad owner seqids and invalid stateid generations. RD10/11 accepted stale and old stateids, while SATT4 resized through a read-only open.

Track open owners and stateid generations in memory, validate WRITE, READ, CLOSE, OPEN_CONFIRM, and SETATTR(SIZE), preserve OPEN, OPEN_CONFIRM and CLOSE replay behavior, and recover CLOSE for staged files after an nfsd restart. Every non-exempt error advances the owner seqid per RFC 7530 §9.1.7, and operations on one owner are serialized, so a retransmit on a second connection gets the cached response.

This adds new state (openStateStore), but it is server-local and in-memory only, not durable or shared across nfsd instances. That is acceptable because a write-open's actual data (the staging file it protects) is itself local-disk and per-host already; a write-open cannot outlive its host regardless of what nfsd tracks about it, so persisting the open state anywhere more durable than the staging file it describes would not add any real guarantee.

State is dropped on CLOSE. Each owner keeps one cached response for replay, and the reboot tombstones and recovered-close cache are FIFO capped. Owners live until CLOSE or client reboot.

Add unit tests to cover the anonymous special stateid handling.

Do not retain or enforce share-deny reservations. They do not match TernFS last-closer-wins semantics and would only be consistent within one nfsd process.