### PR TITLE
 cdc: reject malformed input and roll back recoverable failures

### DIFF
--- a/cpp/cdc/CDC.cpp
+++ b/cpp/cdc/CDC.cpp
@@ -688,6 +688,18 @@ private:
             LOG_DEBUG(_env, "received request id %s, kind %s", cdcMsg.id, cdcMsg.body.kind());
             auto receivedAt = ternNow();
 
+            auto validationError =
+                !CDCLogEntry::itemFits(cdcMsg.body.packedSize(), LogsDB::DEFAULT_UDP_ENTRY_SIZE)
+                ? TernError::MALFORMED_REQUEST
+                : validateCDCRequest(cdcMsg.body);
+            if (unlikely(validationError != TernError::NO_ERROR)) {
+                CDCRespMsg respMsg;
+                respMsg.id = cdcMsg.id;
+                respMsg.body.setError() = validationError;
+                _packCDCResponse(msg.socketIx, msg.clientAddr, cdcMsg.body.kind(), respMsg);
+                continue;
+            }
+
             if (unlikely(cdcMsg.body.kind() == CDCMessageKind::CDC_SNAPSHOT)) {
                 _processCDCSnapshotMessage(cdcMsg, msg);
                 continue;
@@ -749,6 +761,11 @@ private:
             }
             shardResp->checkPoint = respMsg.body.checkPointIdx;
             shardResp->resp = std::move(respMsg.body.resp);
+            if (unlikely(!CDCLogEntry::itemFits(shardResp->packedSize(), LogsDB::DEFAULT_UDP_ENTRY_SIZE))) {
+                RAISE_ALERT(_env, "shard response for request %s is too large to replicate, replacing it with MALFORMED_RESPONSE", respMsg.id);
+                shardResp->checkPoint = 0;
+                shardResp->resp.setError() = TernError::MALFORMED_RESPONSE;
+            }
 
             _recordCDCShardResp(respMsg.id, *shardResp);
         }
@@ -839,6 +856,10 @@ private:
     }
 
     void _packCDCResponse(int sockIx, const IpPort& clientAddr, CDCMessageKind reqKind, const CDCRespMsg& respMsg) {
+        if (unlikely(clientAddr.port == 0)) {
+            LOG_ERROR(_env, "cannot send CDC response for request %s to a zero source port", respMsg.id);
+            return;
+        }
         if (unlikely(respMsg.body.kind() == CDCMessageKind::ERROR)) {
             auto err = respMsg.body.getError();
             LOG_DEBUG(_env, "will send error %s to %s", err, clientAddr);

--- a/cpp/cdc/CDC.cpp
+++ b/cpp/cdc/CDC.cpp
@@ -664,7 +664,7 @@ private:
             } catch (const BincodeException& err) {
                 LOG_ERROR(_env, "could not parse: %s", err.what());
                 RAISE_ALERT(_env, "could not parse LogsDBResponse from %s, dropping it.", msg.clientAddr);
-                requests.pop_back();
+                responses.pop_back();
                 continue;
             }
             LOG_DEBUG(_env, "Received response %s with requests id %s from replica id %s", resp.msg.body.kind(), resp.msg.id, resp.replicaId);

--- a/cpp/cdc/CDCDB.cpp
+++ b/cpp/cdc/CDCDB.cpp
@@ -137,6 +137,27 @@ inline bool createCurrentLockedEdgeRetry(TernError err) {
 
 static constexpr InodeId MOVE_DIRECTORY_LOCK = InodeId::FromU64Unchecked(1ull<<63);
 
+static bool validCDCName(const BincodeBytes& name) {
+    if (name.size() == 0 || name.ref() == BincodeBytesRef(".") || name.ref() == BincodeBytesRef("..")) {
+        return false;
+    }
+    for (int i = 0; i < name.size(); ++i) {
+        if (name.data()[i] == '/' || name.data()[i] == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool validDirectory(InodeId id) {
+    return id != NULL_INODE_ID && id.type() == InodeType::DIRECTORY;
+}
+
+static bool validFile(InodeId id) {
+    return id != NULL_INODE_ID &&
+        (id.type() == InodeType::FILE || id.type() == InodeType::SYMLINK);
+}
+
 struct DirectoriesNeedingLock {
 private:
     static constexpr int MAX_SIZE = 3;
@@ -279,6 +300,13 @@ enum MakeDirectoryStep : uint8_t {
     MAKE_DIRECTORY_UNLOCK_EDGE = 5,
     MAKE_DIRECTORY_ROLLBACK = 6,
 };
+
+static TernError validateRequest(const MakeDirectoryReq& req) {
+    if (req.ownerId == NULL_INODE_ID) return TernError::MALFORMED_REQUEST;
+    if (!validDirectory(req.ownerId)) return TernError::TYPE_IS_NOT_DIRECTORY;
+    if (!validCDCName(req.name)) return TernError::BAD_NAME;
+    return TernError::NO_ERROR;
+}
 
 // Steps:
 //
@@ -498,6 +526,13 @@ enum HardUnlinkDirectoryStep : uint8_t {
     HARD_UNLINK_DIRECTORY_REMOVE_INODE = 1,
 };
 
+static TernError validateRequest(const HardUnlinkDirectoryReq& req) {
+    if (req.dirId == NULL_INODE_ID) return TernError::MALFORMED_REQUEST;
+    if (!validDirectory(req.dirId)) return TernError::TYPE_IS_NOT_DIRECTORY;
+    if (req.dirId == ROOT_DIR_INODE_ID) return TernError::CANNOT_REMOVE_ROOT_DIRECTORY;
+    return TernError::NO_ERROR;
+}
+
 // The only reason we have this here is for possible conflicts with RemoveDirectoryOwner,
 // which might temporarily set the owner of a directory to NULL. Since in the current
 // implementation we only ever have one transaction in flight in the CDC, we can just
@@ -557,6 +592,18 @@ enum RenameFileStep : uint8_t {
     RENAME_FILE_UNLOCK_OLD_EDGE = 5,
     RENAME_FILE_ROLLBACK = 6,
 };
+
+static TernError validateRequest(const RenameFileReq& req) {
+    if (req.targetId == NULL_INODE_ID || req.oldOwnerId == NULL_INODE_ID || req.newOwnerId == NULL_INODE_ID) {
+        return TernError::MALFORMED_REQUEST;
+    }
+    if (!validDirectory(req.oldOwnerId) || !validDirectory(req.newOwnerId)) {
+        return TernError::TYPE_IS_NOT_DIRECTORY;
+    }
+    if (!validFile(req.targetId)) return TernError::TYPE_IS_NOT_DIRECTORY;
+    if (!validCDCName(req.oldName) || !validCDCName(req.newName)) return TernError::BAD_NAME;
+    return TernError::NO_ERROR;
+}
 
 // Steps:
 //
@@ -772,6 +819,17 @@ enum SoftUnlinkDirectoryStep : uint8_t {
     SOFT_UNLINK_DIRECTORY_ROLLBACK = 5,
 };
 
+static TernError validateRequest(const SoftUnlinkDirectoryReq& req) {
+    if (req.ownerId == NULL_INODE_ID || req.targetId == NULL_INODE_ID) {
+        return TernError::MALFORMED_REQUEST;
+    }
+    if (!validDirectory(req.ownerId) || !validDirectory(req.targetId)) {
+        return TernError::TYPE_IS_NOT_DIRECTORY;
+    }
+    if (!validCDCName(req.name)) return TernError::BAD_NAME;
+    return TernError::NO_ERROR;
+}
+
 // Steps:
 //
 // 1. Lock edge going into the directory to remove. This prevents things making
@@ -959,6 +1017,17 @@ enum RenameDirectoryStep : uint8_t {
     RENAME_DIRECTORY_SET_OWNER = 6,
     RENAME_DIRECTORY_ROLLBACK = 7,
 };
+
+static TernError validateRequest(const RenameDirectoryReq& req) {
+    if (req.targetId == NULL_INODE_ID || req.oldOwnerId == NULL_INODE_ID || req.newOwnerId == NULL_INODE_ID) {
+        return TernError::MALFORMED_REQUEST;
+    }
+    if (!validDirectory(req.targetId) || !validDirectory(req.oldOwnerId) || !validDirectory(req.newOwnerId)) {
+        return TernError::TYPE_IS_NOT_DIRECTORY;
+    }
+    if (!validCDCName(req.oldName) || !validCDCName(req.newName)) return TernError::BAD_NAME;
+    return TernError::NO_ERROR;
+}
 
 // Steps:
 //
@@ -1233,6 +1302,16 @@ enum CrossShardHardUnlinkFileStep : uint8_t {
     CROSS_SHARD_HARD_UNLINK_FILE_MAKE_TRANSIENT = 2,
 };
 
+static TernError validateRequest(const CrossShardHardUnlinkFileReq& req) {
+    if (req.ownerId == NULL_INODE_ID || req.targetId == NULL_INODE_ID) {
+        return TernError::MALFORMED_REQUEST;
+    }
+    if (!validDirectory(req.ownerId)) return TernError::TYPE_IS_NOT_DIRECTORY;
+    if (!validFile(req.targetId)) return TernError::TYPE_IS_DIRECTORY;
+    if (!validCDCName(req.name)) return TernError::BAD_NAME;
+    return TernError::NO_ERROR;
+}
+
 // Steps:
 //
 // 1. Remove owning edge in one shard
@@ -1315,6 +1394,29 @@ struct CrossShardHardUnlinkFileStateMachine {
     }
 };
 
+TernError validateCDCRequest(const CDCReqContainer& req) {
+    switch (req.kind()) {
+    case CDCMessageKind::MAKE_DIRECTORY:
+        return validateRequest(req.getMakeDirectory());
+    case CDCMessageKind::RENAME_FILE:
+        return validateRequest(req.getRenameFile());
+    case CDCMessageKind::SOFT_UNLINK_DIRECTORY:
+        return validateRequest(req.getSoftUnlinkDirectory());
+    case CDCMessageKind::RENAME_DIRECTORY:
+        return validateRequest(req.getRenameDirectory());
+    case CDCMessageKind::CROSS_SHARD_HARD_UNLINK_FILE:
+        return validateRequest(req.getCrossShardHardUnlinkFile());
+    case CDCMessageKind::HARD_UNLINK_DIRECTORY:
+        return validateRequest(req.getHardUnlinkDirectory());
+    case CDCMessageKind::CDC_SNAPSHOT:
+        return TernError::NO_ERROR;
+    case CDCMessageKind::ERROR:
+    case CDCMessageKind::EMPTY:
+        return TernError::MALFORMED_REQUEST;
+    }
+    return TernError::MALFORMED_REQUEST;
+}
+
 void CDCShardResp::pack(BincodeBuf& buf) const {
     buf.packScalar(txnId.x);
     checkPoint.pack(buf);
@@ -1336,7 +1438,7 @@ void CDCLogEntry::prepareLogEntries(std::vector<CDCReqContainer>& cdcReqs, std::
     CDCLogEntry* curEntry{nullptr};
     for (auto& shardResp : shardResps) {
         auto respSize = shardResp.packedSize();
-        ALWAYS_ASSERT(respSize < maxPackedSize);
+        ALWAYS_ASSERT(itemFits(respSize, maxPackedSize));
         if (unlikely(maxPackedSize - respSize < usedSize)) {
             curEntry = &entriesOut.emplace_back();
             usedSize = curEntry->packedSize();
@@ -1347,7 +1449,7 @@ void CDCLogEntry::prepareLogEntries(std::vector<CDCReqContainer>& cdcReqs, std::
     }
     for (auto& cdcReq : cdcReqs) {
         auto reqSize = cdcReq.packedSize();
-        ALWAYS_ASSERT(reqSize < maxPackedSize);
+        ALWAYS_ASSERT(itemFits(reqSize, maxPackedSize));
         if (unlikely(maxPackedSize - reqSize < usedSize)) {
             curEntry = &entriesOut.emplace_back();
             usedSize = curEntry->packedSize();
@@ -1391,7 +1493,7 @@ void CDCLogEntry::unpack(BincodeBuf& buf) {
 }
 
 size_t CDCLogEntry::packedSize() const {
-    size_t size{1 + 2 * sizeof(uint32_t)};
+    size_t size{FIXED_PACKED_SIZE};
     for (auto& cdcReq : _cdcReqs) {
         size += cdcReq.packedSize();
     }

--- a/cpp/cdc/CDCDB.cpp
+++ b/cpp/cdc/CDCDB.cpp
@@ -916,6 +916,9 @@ struct SoftUnlinkDirectoryStateMachine {
         auto err = resp.kind() == ShardMessageKind::ERROR ? resp.getError() : TernError::NO_ERROR;
         if (err == TernError::TIMEOUT) {
             stat(true); // retry
+        } else if (err == TernError::MALFORMED_RESPONSE) {
+            state.setExitError(err);
+            rollback();
         } else {
             ALWAYS_ASSERT(err == TernError::NO_ERROR);
             const auto& statResp = resp.getStatDirectory();

--- a/cpp/cdc/CDCDB.cpp
+++ b/cpp/cdc/CDCDB.cpp
@@ -1481,12 +1481,32 @@ void CDCLogEntry::pack(BincodeBuf& buf) const {
 }
 
 void CDCLogEntry::unpack(BincodeBuf& buf) {
-    _bootstrapEntry = buf.unpackScalar<bool>();
-    _cdcReqs.resize(buf.unpackScalar<uint32_t>());
+    auto bootstrapEntry = buf.unpackScalar<uint8_t>();
+    if (unlikely(bootstrapEntry > 1)) {
+        throw BINCODE_EXCEPTION(
+            "invalid CDC bootstrap entry flag %s",
+            bootstrapEntry);
+    }
+    _bootstrapEntry = bootstrapEntry;
+    auto cdcReqCount = buf.unpackScalar<uint32_t>();
+    if (unlikely(cdcReqCount > buf.remaining())) {
+        throw BINCODE_EXCEPTION(
+            "CDC request count %s cannot fit in %s remaining bytes",
+            cdcReqCount,
+            buf.remaining());
+    }
+    _cdcReqs.resize(cdcReqCount);
     for (auto& cdcReq : _cdcReqs) {
         cdcReq.unpack(buf);
     }
-    _shardResps.resize(buf.unpackScalar<uint32_t>());
+    auto shardRespCount = buf.unpackScalar<uint32_t>();
+    if (unlikely(shardRespCount > buf.remaining())) {
+        throw BINCODE_EXCEPTION(
+            "CDC shard response count %s cannot fit in %s remaining bytes",
+            shardRespCount,
+            buf.remaining());
+    }
+    _shardResps.resize(shardRespCount);
     for (auto& shardResp : _shardResps) {
         shardResp.unpack(buf);
     }

--- a/cpp/cdc/CDCDB.hpp
+++ b/cpp/cdc/CDCDB.hpp
@@ -82,6 +82,13 @@ std::ostream& operator<<(std::ostream& out, const CDCShardResp& x);
 
 class CDCLogEntry {
 public:
+    static constexpr size_t FIXED_PACKED_SIZE = 1 + 2 * sizeof(uint32_t);
+
+    static constexpr bool itemFits(size_t itemPackedSize, size_t maxPackedSize) {
+        return maxPackedSize >= FIXED_PACKED_SIZE &&
+            itemPackedSize <= maxPackedSize - FIXED_PACKED_SIZE;
+    }
+
     static void prepareLogEntries(std::vector<CDCReqContainer>& cdcReqs, std::vector<CDCShardResp>& shardResps, size_t maxPackedSize, std::vector<CDCLogEntry>& entriesOut);
     static CDCLogEntry prepareBootstrapEntry();
 
@@ -119,6 +126,8 @@ private:
 };
 
 std::ostream& operator<<(std::ostream& out, const CDCLogEntry& x);
+
+TernError validateCDCRequest(const CDCReqContainer& req);
 
 struct CDCDB {
 private:

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-include_directories(${ternfs_SOURCE_DIR}/core ${ternfs_SOURCE_DIR}/shard ${ternfs_SOURCE_DIR}/registry)
+include_directories(${ternfs_SOURCE_DIR}/core ${ternfs_SOURCE_DIR}/shard ${ternfs_SOURCE_DIR}/registry ${ternfs_SOURCE_DIR}/cdc)
 
 add_executable(tests tests.cpp doctest.h)
 target_link_libraries(tests PRIVATE core shard cdc)

--- a/cpp/tests/tests.cpp
+++ b/cpp/tests/tests.cpp
@@ -20,6 +20,7 @@
 #include "SharedRocksDB.hpp"
 #include "Time.hpp"
 #include "CDCKey.hpp"
+#include "CDCDB.hpp"
 #include "Random.hpp"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
@@ -71,6 +72,43 @@ TEST_CASE("BincodeBytes") {
         CHECK(bytes.size() == i);
         CHECK(strncmp(bytes.data(), buf, bytes.size()) == 0);
     }
+}
+
+TEST_CASE("CDC log items leave room for their entry header") {
+    CHECK(CDCLogEntry::itemFits(91, 100));
+    CHECK_FALSE(CDCLogEntry::itemFits(92, 100));
+    CHECK_FALSE(CDCLogEntry::itemFits(0, 8));
+}
+
+TEST_CASE("CDC rejects malformed request fields before replication") {
+    const InodeId dir1(InodeType::DIRECTORY, ShardId(1), 1);
+    const InodeId dir2(InodeType::DIRECTORY, ShardId(2), 2);
+    const InodeId file(InodeType::FILE, ShardId(3), 3);
+
+    CDCReqContainer req;
+    auto& makeDirectory = req.setMakeDirectory();
+    makeDirectory.ownerId = NULL_INODE_ID;
+    makeDirectory.name = BincodeBytes("name");
+    CHECK(validateCDCRequest(req) == TernError::MALFORMED_REQUEST);
+
+    makeDirectory.ownerId = dir1;
+    makeDirectory.name = BincodeBytes("");
+    CHECK(validateCDCRequest(req) == TernError::BAD_NAME);
+
+    auto& renameFile = req.setRenameFile();
+    renameFile.targetId = file;
+    renameFile.oldOwnerId = dir1;
+    renameFile.oldName = BincodeBytes("old");
+    renameFile.newOwnerId = dir2;
+    renameFile.newName = BincodeBytes("new");
+    CHECK(validateCDCRequest(req) == TernError::NO_ERROR);
+
+    renameFile.newOwnerId = file;
+    CHECK(validateCDCRequest(req) == TernError::TYPE_IS_NOT_DIRECTORY);
+
+    auto& hardUnlink = req.setHardUnlinkDirectory();
+    hardUnlink.dirId = ROOT_DIR_INODE_ID;
+    CHECK(validateCDCRequest(req) == TernError::CANNOT_REMOVE_ROOT_DIRECTORY);
 }
 
 struct TempRocksDB {

--- a/cpp/tests/tests.cpp
+++ b/cpp/tests/tests.cpp
@@ -80,6 +80,32 @@ TEST_CASE("CDC log items leave room for their entry header") {
     CHECK_FALSE(CDCLogEntry::itemFits(0, 8));
 }
 
+TEST_CASE("CDC log entries reject corrupt fixed fields before allocation") {
+    SUBCASE("bootstrap flag") {
+        char buf[] = {2};
+        BincodeBuf bbuf(buf, sizeof(buf));
+        CDCLogEntry entry;
+
+        CHECK_THROWS_AS(entry.unpack(bbuf), BincodeException);
+    }
+
+    SUBCASE("request count") {
+        char buf[] = {0, 1, 0, 0, 0};
+        BincodeBuf bbuf(buf, sizeof(buf));
+        CDCLogEntry entry;
+
+        CHECK_THROWS_AS(entry.unpack(bbuf), BincodeException);
+    }
+
+    SUBCASE("shard response count") {
+        char buf[] = {0, 0, 0, 0, 0, 1, 0, 0, 0};
+        BincodeBuf bbuf(buf, sizeof(buf));
+        CDCLogEntry entry;
+
+        CHECK_THROWS_AS(entry.unpack(bbuf), BincodeException);
+    }
+}
+
 TEST_CASE("CDC rejects malformed request fields before replication") {
     const InodeId dir1(InodeType::DIRECTORY, ShardId(1), 1);
     const InodeId dir2(InodeType::DIRECTORY, ShardId(2), 2);


### PR DESCRIPTION
 ## Summary

 Harden CDC request, response and persisted-log handling.

- Validate CDC requests before replicating them.
- Account for the CDC log-entry header when enforcing replication limits.
- Replace oversized shard responses with `MALFORMED_RESPONSE`.
- Remove malformed LogsDB responses from the correct response batch.
- Avoid sending CDC responses to a zero source port.
- Validate persisted entry fields before allocating request and response vectors.
- Roll back `SoftUnlinkDirectory` when an oversized `STAT_DIRECTORY` response cannot be replicated.

This PR should be reviewed patch by patch.

## Safety
Valid requests, responses that fit within the replication limit, and successful transactions follow the existing paths. There are no wire-format or storage-format changes.

Malformed client requests are rejected before entering LogsDB. Malformed LogsDB responses are dropped. Successfully decoded internal response contract violations remain assertions.

Corrupt persisted metadata still stops CDC processing through `BincodeException`. The new checks stop before decoding an invalid boolean or allocating vectors from corrupt counts.

The only new rollback path handles an oversized `STAT_DIRECTORY` response during `SoftUnlinkDirectory`. At that point the source edge has been locked but no irreversible operation has occurred, so CDC unlocks it before returning `MALFORMED_RESPONSE`.
