### PR TITLE
 ternblocks: handle invalid writes and startup failures better

### DIFF
--- a/go/ternblocks/ternblocks.go
+++ b/go/ternblocks/ternblocks.go
@@ -1154,7 +1154,9 @@ func retrieveOrCreateKey(log *log.Logger, dir string) ([16]byte, error) {
 	if err != nil {
 		return [16]byte{}, fmt.Errorf("could not open or create key file %v: %v", keyFilePath, err)
 	}
-	keyFile.Seek(0, 0)
+	if _, err := keyFile.Seek(0, 0); err != nil {
+		return [16]byte{}, fmt.Errorf("could not seek key file %v: %w", keyFilePath, err)
+	}
 	if err := syscall.Flock(int(keyFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		return [16]byte{}, fmt.Errorf("could not lock key file %v: %v", keyFilePath, err)
 	}
@@ -1167,14 +1169,14 @@ func retrieveOrCreateKey(log *log.Logger, dir string) ([16]byte, error) {
 	if err == io.EOF {
 		log.Info("creating new secret key")
 		if _, err := crand.Read(key[:]); err != nil {
-			panic(err)
+			return [16]byte{}, fmt.Errorf("could not generate key for %v: %w", keyFilePath, err)
 		}
 		if _, err := keyFile.Write(key[:]); err != nil {
-			panic(err)
+			return [16]byte{}, fmt.Errorf("could not write key file %v: %w", keyFilePath, err)
 		}
 		keyCrc := crc32c.Sum(0, key[:])
 		if err := binary.Write(keyFile, binary.LittleEndian, keyCrc); err != nil {
-			panic(err)
+			return [16]byte{}, fmt.Errorf("could not write crc to key file %v: %w", keyFilePath, err)
 		}
 		log.Info("creating directory structure")
 		if err := os.Mkdir(path.Join(dir, "with_crc"), 0755); err != nil && !os.IsExist(err) {

--- a/go/ternblocks/ternblocks.go
+++ b/go/ternblocks/ternblocks.go
@@ -1054,6 +1054,9 @@ func handleSingleRequest(
 			return handleRequestError(log, blockServices, deadBlockServices, conn, lastError, blockServiceId, kind, err)
 		}
 	case *msgs.WriteBlockReq:
+		if err := checkWriteCertificate(log, blockService.cipher, blockServiceId, whichReq, env.stats[blockServiceId]); err != nil {
+			return handleRequestError(log, blockServices, deadBlockServices, conn, lastError, blockServiceId, kind, err)
+		}
 		pastCutoffTime := msgs.TernTime(uint64(whichReq.BlockId)).Time().Add(-PAST_CUTOFF)
 		futureCutoffTime := msgs.TernTime(uint64(whichReq.BlockId)).Time().Add(WRITE_FUTURE_CUTOFF)
 		now := time.Now()
@@ -1064,9 +1067,6 @@ func handleSingleRequest(
 			log.ErrorNoAlert("block %v is too old to be written (now=%v, futureCutoffTime=%v)", whichReq.BlockId, now, futureCutoffTime)
 			atomic.AddUint64(&env.stats[blockServiceId].blockTooOldForWrite, 1)
 			return handleRequestError(log, blockServices, deadBlockServices, conn, lastError, blockServiceId, kind, msgs.BLOCK_TOO_OLD_FOR_WRITE)
-		}
-		if err := checkWriteCertificate(log, blockService.cipher, blockServiceId, whichReq, env.stats[blockServiceId]); err != nil {
-			return handleRequestError(log, blockServices, deadBlockServices, conn, lastError, blockServiceId, kind, err)
 		}
 		if whichReq.Size > MAX_OBJECT_SIZE {
 			log.RaiseAlert("block %v exceeds max object size: %v > %v", whichReq.BlockId, whichReq.Size, MAX_OBJECT_SIZE)

--- a/go/ternblocks/ternblocks.go
+++ b/go/ternblocks/ternblocks.go
@@ -240,6 +240,7 @@ func initBlockServicesInfo(
 	log.Info("initializing block services info")
 	var wg sync.WaitGroup
 	wg.Add(len(blockServices))
+	errs := make(chan error, len(blockServices))
 	alert := log.NewNCAlert(0)
 	log.RaiseNC(alert, "getting info for %v block services", len(blockServices))
 	for id, bs := range blockServices {
@@ -256,20 +257,35 @@ func initBlockServicesInfo(
 		}
 		closureBs := bs
 		go func() {
+			defer wg.Done()
 			// only update if it isn't filled it in already from registry
 			if closureBs.cachedInfo.Blocks == 0 {
 				if err := updateBlockServiceInfoCapacity(log, closureBs, reservedStorage); err != nil {
-					panic(err)
+					errs <- fmt.Errorf(
+						"could not read capacity for block service %v at %v: %w",
+						closureBs.cachedInfo.Id,
+						closureBs.path,
+						err,
+					)
+					return
 				}
 				if err := updateBlockServiceInfoBlocks(log, closureBs); err != nil {
-					panic(err)
+					errs <- fmt.Errorf(
+						"could not scan blocks for block service %v at %v: %w",
+						closureBs.cachedInfo.Id,
+						closureBs.path,
+						err,
+					)
 				}
 			}
-			wg.Done()
 		}()
 	}
 	wg.Wait()
+	close(errs)
 	log.ClearNC(alert)
+	for err := range errs {
+		return err
+	}
 	return nil
 }
 
@@ -1727,7 +1743,10 @@ func main() {
 		actualPort2 = uint16(listener2.Addr().(*net.TCPAddr).Port)
 	}
 
-	initBlockServicesInfo(env, l, msgs.Location(*locationId), msgs.AddrsInfo{Addr1: msgs.IpPort{Addrs: ownIp1, Port: actualPort1}, Addr2: msgs.IpPort{Addrs: ownIp2, Port: actualPort2}}, failureDomain, blockServices, *reservedStorage)
+	if err := initBlockServicesInfo(env, l, msgs.Location(*locationId), msgs.AddrsInfo{Addr1: msgs.IpPort{Addrs: ownIp1, Port: actualPort1}, Addr2: msgs.IpPort{Addrs: ownIp2, Port: actualPort2}}, failureDomain, blockServices, *reservedStorage); err != nil {
+		l.RaiseAlert("could not initialize block services: %v", err)
+		os.Exit(1)
+	}
 	l.Info("finished updating block service info, will now start")
 
 	terminateChan := make(chan any)

--- a/go/ternblocks/ternblocks_test.go
+++ b/go/ternblocks/ternblocks_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"xtx/ternfs/core/log"
+	"xtx/ternfs/msgs"
+)
+
+func TestInitBlockServicesInfoReturnsStorageReadErrors(t *testing.T) {
+	logFile, err := os.CreateTemp(t.TempDir(), "ternblocks-test-log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logFile.Close()
+	logger := log.NewLogger(logFile, &log.LoggerOptions{Level: log.ERROR})
+	missingPath := t.TempDir() + "/missing"
+	blockServices := map[msgs.BlockServiceId]*blockService{
+		1: {path: missingPath},
+	}
+
+	err = initBlockServicesInfo(
+		&env{},
+		logger,
+		0,
+		msgs.AddrsInfo{},
+		[16]byte{},
+		blockServices,
+		0,
+	)
+	if err == nil {
+		t.Fatal("initBlockServicesInfo() succeeded for a missing storage path")
+	}
+}


### PR DESCRIPTION
## Summary

Harden ternblocks request validation and storage initialization.

- Authenticate write requests before checking fatal block timestamp invariants.
- Return storage capacity and block-scan errors from initialization workers, so that the error message is returned rather than a go routine panic.
- Propagate key-file seek, generation and write errors through the existing initialization error path.

## Safety

Authenticated writes follow the existing path. Certified future block IDs
remain fatal because they indicate an allocator or clock failure. Arbitrary
unauthenticated block IDs now return `BAD_CERTIFICATE` before reaching that
invariant.

Storage scan failures still stop startup. They now produce a controlled alert
and exit rather than panicking inside a worker goroutine.

Key-file errors use the same existing path as open and lock failures. Valid key
files and newly created keys retain the existing format.

There are no wire-format or storage-format changes. This branch can be deployed
independently.
