### PR TITLE
core: reject malformed bincode input safely

### DIFF
--- a/cpp/core/Bincode.hpp
+++ b/cpp/core/Bincode.hpp
@@ -288,7 +288,11 @@ struct BincodeBuf {
     }
 
     void ensureFinished() const {
-        ALWAYS_ASSERT(remaining() == 0);
+        if (unlikely(remaining() != 0)) {
+            throw BINCODE_EXCEPTION(
+                "buffer has %s trailing bytes after decoding",
+                remaining());
+        }
     }
 
     void ensureSizeOrPanic(size_t sz) const {
@@ -372,23 +376,28 @@ struct BincodeBuf {
 
     template<typename A>
     void unpackList(BincodeList<A>& xs) {
-        xs.els.resize(unpackScalar<uint16_t>());
-        if (unlikely(xs.els.size() == 0)) {
+        size_t count = unpackScalar<uint16_t>();
+        if (unlikely(count == 0)) {
+            xs.els.clear();
             return;
         }
         // If it's a number of some sorts, just memcpy it
         if constexpr (std::is_integral_v<A> || std::is_enum_v<A>) {
             static_assert(std::endian::native == std::endian::little);
-            size_t sz = sizeof(A)*xs.els.size();
+            size_t sz = sizeof(A)*count;
             if (unlikely(remaining() < sz)) {
                 throw BINCODE_EXCEPTION("not enough bytes to unpack scalars (need %s, got %s)", sz, remaining());
             }
+            xs.els.resize(count);
             memcpy(xs.els.data(), cursor, sz);
             cursor += sz;
         } else {
-            for (int i = 0; i < xs.els.size(); i++) {
-                xs.els[i].unpack(*this);
+            std::vector<A> els;
+            for (size_t i = 0; i < count; i++) {
+                auto& el = els.emplace_back();
+                el.unpack(*this);
             }
+            xs.els = std::move(els);
         }
     }
 

--- a/cpp/tests/tests.cpp
+++ b/cpp/tests/tests.cpp
@@ -51,6 +51,38 @@ TEST_CASE("bincode u16") { bincodeTestScalar<uint16_t>(); }
 TEST_CASE("bincode u32") { bincodeTestScalar<uint32_t>(); }
 TEST_CASE("bincode u64") { bincodeTestScalar<uint64_t>(); }
 
+struct FourByteBincodeValue {
+    static inline size_t constructed = 0;
+
+    uint32_t value;
+
+    FourByteBincodeValue() {
+        constructed++;
+    }
+
+    void unpack(BincodeBuf& buf) {
+        value = buf.unpackScalar<uint32_t>();
+    }
+};
+
+TEST_CASE("bincode rejects trailing bytes") {
+    char buf[] = {'x'};
+    BincodeBuf bbuf(buf, sizeof(buf));
+
+    CHECK_THROWS_AS(bbuf.ensureFinished(), BincodeException);
+}
+
+TEST_CASE("bincode decodes complex lists without allocating from count") {
+    char buf[] = {-1, -1};
+    BincodeBuf bbuf(buf, sizeof(buf));
+    BincodeList<FourByteBincodeValue> values;
+    FourByteBincodeValue::constructed = 0;
+
+    CHECK_THROWS_AS(bbuf.unpackList(values), BincodeException);
+    CHECK(values.els.empty());
+    CHECK(FourByteBincodeValue::constructed == 1);
+}
+
 TEST_CASE("LeaderToken epoch encoding") {
     LeaderToken token(ReplicaId(3), Epoch(42));
 


### PR DESCRIPTION
Convert trailing-byte validation into a BincodeException instead of an assertion failure. Check integral list payload sizes before allocation, and decode complex lists incrementally so an untrusted count cannot trigger a bulk allocation.

Valid encodings and their wire format are unchanged.