### PR TITLE
kmod: add GCC allocation analysis and fix cleanup paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,10 +161,18 @@ jobs:
           apt-get install -y --no-install-recommends fakeroot llvm libncurses-dev dwarves
       - name: Download base qemu image
         run: curl -fsSL -O https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+      - name: Prepare kmod image
+        run: ./ci.py --prepare-image ${{ github.workspace }}/noble-server-cloudimg-amd64.img
+      - name: Analyze kmod allocations
+        run: |
+          make -C kmod \
+            KDIR="$PWD/kmod/linux" \
+            -j"$(nproc)" \
+            ternfs-client-analyzer
       - name: Run kmod tests
-        run: ./ci.py --short --prepare-image ${{ github.workspace }}/noble-server-cloudimg-amd64.img --kmod --leader-only
+        run: ./ci.py --short --kmod --leader-only
       - name: Run NFS tests
-        run: ./ci.py --short --prepare-image ${{ github.workspace }}/noble-server-cloudimg-amd64.img --nfs --leader-only
+        run: ./ci.py --short --nfs --leader-only
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -40,6 +40,10 @@ ternfs-client-objs += \
 	revision.o \
 	policy.o
 
+ifeq ($(TERNFS_FANALYZER_BUILD),1)
+ternfs-client-objs += fanalyzer.o
+endif
+
 HAVE_INODE_ATIME_ACCESSORS := $(shell grep -q inode_get_atime_sec \
     $(srctree)/include/linux/fs.h 2>/dev/null && echo 1)
 
@@ -47,6 +51,19 @@ EXTRA_CFLAGS = -I$(src) -g -DDEBUG -fdiagnostics-color=always -Wno-declaration-a
 ifeq ($(HAVE_INODE_ATIME_ACCESSORS),1)
   EXTRA_CFLAGS += -DHAVE_INODE_ATIME_ACCESSORS
 endif
+
+FANALYZER_CFLAGS := \
+	-fanalyzer \
+	-DTERNFS_FANALYZER \
+	-D__NO_FORTIFY \
+	-include $(CURDIR)/fanalyzer.h \
+	-Werror=analyzer-double-free \
+	-Werror=analyzer-free-of-non-heap \
+	-Werror=analyzer-malloc-leak \
+	-Werror=analyzer-mismatching-deallocation \
+	-Werror=analyzer-null-dereference \
+	-Wno-analyzer-use-of-uninitialized-value \
+	-Wno-analyzer-use-after-free
 
 export CF = -Wbitwise -Wcontext -Wcast_truncate -Wsparse-all -Wno-shadow -Wnopointer-arith -Wnosizeof-bool -DCONFIG_SPARSE_RCU_POINTER
 
@@ -104,5 +121,10 @@ ternfs-client:
 # We don't want sparse as a dependency.
 ternfs-client-local: revision.c extra-files
 	$(MAKE) -C $(KDIR) M=$(CURDIR) modules
+
+# GCC's analyzer is deliberately separate from normal builds because it is
+# substantially slower and its allocator model is only enabled by fanalyzer.h.
+ternfs-client-analyzer: revision.c extra-files
+	$(MAKE) -C $(KDIR) M=$(CURDIR) TERNFS_FANALYZER_BUILD=1 KCFLAGS="$(FANALYZER_CFLAGS)" modules
 
 clean: ternfs-client-clean bincode_tests-clean

--- a/kmod/block.c
+++ b/kmod/block.c
@@ -171,6 +171,9 @@ static void mark_bad_addr(__be32 ip, __be16 port) {
     bad_addrs_count++;
     atomic_inc(&bad_addrs_live);
     spin_unlock(&bad_addrs_lock);
+#ifdef TERNFS_FANALYZER
+    ternfs_fanalyzer_escape(new_entry);
+#endif
 }
 
 static void bad_addrs_clear(void) {

--- a/kmod/debugfs.c
+++ b/kmod/debugfs.c
@@ -42,14 +42,14 @@ int __init ternfs_debugfs_init(void) {
 
     // Headers
     shard_stats_header = kzalloc(sizeof(struct ternfs_stats_header), GFP_KERNEL);
-    if (IS_ERR(shard_stats_header)) {
-        err = PTR_ERR(shard_stats_header);
+    if (!shard_stats_header) {
+        err = -ENOMEM;
         goto out_shard_stats_header;
     }
 
     cdc_stats_header = kzalloc(sizeof(struct ternfs_stats_header), GFP_KERNEL);
-    if (IS_ERR(cdc_stats_header)) {
-        err = PTR_ERR(cdc_stats_header);
+    if (!cdc_stats_header) {
+        err = -ENOMEM;
         goto out_cdc_stats_header;
     }
 
@@ -73,41 +73,43 @@ int __init ternfs_debugfs_init(void) {
     // Metrics
 
     shard_counters = (u64 *)vzalloc(TERNFS_SHARD_COUNTERS_SIZE);
-    if (IS_ERR(shard_counters)) {
-        err = PTR_ERR(shard_counters);
+    if (!shard_counters) {
+        err = -ENOMEM;
         goto out_shard_counters;
     }
 
     cdc_counters = (u64 *)vzalloc(TERNFS_CDC_COUNTERS_SIZE);
-    if (IS_ERR(cdc_counters)) {
-        err = PTR_ERR(cdc_counters);
+    if (!cdc_counters) {
+        err = -ENOMEM;
         goto out_cdc_counters;
     }
 
     // Timings
     shard_latencies = vzalloc(TERNFS_SHARD_LATENCIES_SIZE);
-    if (IS_ERR(shard_latencies)) {
-        err = PTR_ERR(shard_latencies);
+    if (!shard_latencies) {
+        err = -ENOMEM;
         goto out_shard_latencies;
     }
 
     cdc_latencies = vzalloc(TERNFS_CDC_LATENCIES_SIZE);
-    if (IS_ERR(cdc_latencies)) {
-        err = PTR_ERR(cdc_latencies);
+    if (!cdc_latencies) {
+        err = -ENOMEM;
         goto out_cdc_latencies;
     }
 
     ternfs_debugfs_root = debugfs_create_dir(TERNFS_ROOT_DEBUGFS_NAME, NULL);
     if (IS_ERR(ternfs_debugfs_root)) {
         err = PTR_ERR(ternfs_debugfs_root);
-        goto out_err; // debugfs_remove_recursive handles NULL parameter value
+        ternfs_debugfs_root = NULL;
+        goto out_err;
     }
 
     struct dentry *d;
 #define TERNFS_DEBUGFS_FILE(_name, _size, _stat_name) ({ \
         debug_wrapper_##_name = kzalloc(sizeof(struct debugfs_blob_wrapper), GFP_KERNEL); \
-        if (IS_ERR(debug_wrapper_##_name)) { \
-            return PTR_ERR(debug_wrapper_##_name); \
+        if (!debug_wrapper_##_name) { \
+            err = -ENOMEM; \
+            goto out_err; \
         } \
         debug_wrapper_##_name->data = _name; \
         debug_wrapper_##_name->size = _size; \
@@ -163,4 +165,6 @@ void __cold ternfs_debugfs_exit(void) {
     kfree(debug_wrapper_shard_stats_header);
     kfree(debug_wrapper_cdc_counters);
     kfree(debug_wrapper_cdc_stats_header);
+    kfree(debug_wrapper_shard_latencies);
+    kfree(debug_wrapper_cdc_latencies);
 }

--- a/kmod/fanalyzer.c
+++ b/kmod/fanalyzer.c
@@ -1,0 +1,8 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "fanalyzer.h"
+
+void ternfs_fanalyzer_escape(const void *ptr) {
+}

--- a/kmod/fanalyzer.h
+++ b/kmod/fanalyzer.h
@@ -1,0 +1,62 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifndef _TERNFS_FANALYZER_H
+#define _TERNFS_FANALYZER_H
+
+#ifndef TERNFS_FANALYZER
+#error "fanalyzer.h is only for the GCC -fanalyzer build"
+#endif
+
+#if !defined(__GNUC__) || defined(__clang__) || __GNUC__ < 11
+#error "TernFS allocator analysis requires GCC 11 or newer"
+#endif
+
+#include <linux/slab.h>
+#include <linux/vmalloc.h>
+
+void ternfs_fanalyzer_escape(const void *ptr);
+
+#define TERNFS_MALLOC_DEALLOC(_deallocator, _pointer_arg) \
+    __attribute__(( \
+        malloc(_deallocator, _pointer_arg), \
+        malloc(ternfs_fanalyzer_escape, 1) \
+    ))
+
+/*
+ * The kernel's __malloc annotation has no deallocator, so GCC's analyzer
+ * does not otherwise know which calls release these allocations.
+ */
+void *__kmalloc_noprof(size_t size, gfp_t flags)
+    TERNFS_MALLOC_DEALLOC(kfree, 1);
+void *__kmalloc_node_noprof(DECL_BUCKET_PARAMS(size, b), gfp_t flags, int node)
+    TERNFS_MALLOC_DEALLOC(kfree, 1);
+void *__kmalloc_cache_noprof(struct kmem_cache *s, gfp_t flags, size_t size)
+    TERNFS_MALLOC_DEALLOC(kfree, 1);
+void *__kmalloc_cache_node_noprof(
+    struct kmem_cache *s, gfp_t gfpflags, int node, size_t size
+) TERNFS_MALLOC_DEALLOC(kfree, 1);
+void *__kmalloc_large_noprof(size_t size, gfp_t flags)
+    TERNFS_MALLOC_DEALLOC(kfree, 1);
+void *__kmalloc_large_node_noprof(size_t size, gfp_t flags, int node)
+    TERNFS_MALLOC_DEALLOC(kfree, 1);
+
+void *kmem_cache_alloc_noprof(struct kmem_cache *cachep, gfp_t flags)
+    TERNFS_MALLOC_DEALLOC(kmem_cache_free, 2);
+
+void *vmalloc_noprof(unsigned long size)
+    TERNFS_MALLOC_DEALLOC(vfree, 1);
+void *vzalloc_noprof(unsigned long size)
+    TERNFS_MALLOC_DEALLOC(vfree, 1);
+
+struct kmem_cache *__kmem_cache_create_args(
+    const char *name,
+    unsigned int object_size,
+    struct kmem_cache_args *args,
+    slab_flags_t flags
+) TERNFS_MALLOC_DEALLOC(kmem_cache_destroy, 1);
+
+#undef TERNFS_MALLOC_DEALLOC
+
+#endif

--- a/kmod/span.c
+++ b/kmod/span.c
@@ -865,14 +865,16 @@ static void file_spans_cb_span(void* data, u64 offset, u32 size, u32 crc, u8 sto
     }
 
     struct ternfs_block_span* span = kmem_cache_alloc(ternfs_block_span_cachep, GFP_KERNEL);
-    if (!span) { ctx->err = -ENOMEM; return; }
+    if (!span) {
+        ctx->err = -ENOMEM;
+        return;
+    }
     atomic_set(&span->span.refcount, 1);
 
     if (ternfs_data_blocks(parity) > TERNFS_MAX_DATA || ternfs_parity_blocks(parity) > TERNFS_MAX_PARITY) {
         ternfs_error("file=%016llx offset=%llu invalid parity config D=%d (max=%d) P=%d (max=%d)", ctx->ino, offset, ternfs_data_blocks(parity), TERNFS_MAX_DATA, ternfs_parity_blocks(parity), TERNFS_MAX_PARITY);
         ctx->err = -EIO;
-        ternfs_put_span(&span->span);
-        return;
+        goto out_free;
     }
 
     span->span.ino = ctx->ino;
@@ -884,7 +886,16 @@ static void file_spans_cb_span(void* data, u64 offset, u32 size, u32 crc, u8 sto
     span->num_stripes = stripes;
     span->parity = parity;
     ternfs_debug("adding normal span");
-    insert_span(&ctx->spans, &span->span);
+    if (!insert_span(&ctx->spans, &span->span)) {
+        ctx->err = -EIO;
+        goto out_free;
+    }
+
+    return;
+
+out_free:
+    kmem_cache_free(ternfs_block_span_cachep, span);
+    return;
 }
 
 static void file_spans_cb_block(
@@ -924,7 +935,10 @@ static void file_spans_cb_inline_span(void* data, u64 offset, u32 size, u8 len, 
     }
 
     struct ternfs_inline_span* span = kmem_cache_alloc(ternfs_inline_span_cachep, GFP_KERNEL);
-    if (!span) { ctx->err = -ENOMEM; return; }
+    if (!span) {
+        ctx->err = -ENOMEM;
+        return;
+    }
     atomic_set(&span->span.refcount, 1);
 
     span->span.ino = ctx->ino;
@@ -937,7 +951,11 @@ static void file_spans_cb_inline_span(void* data, u64 offset, u32 size, u8 len, 
 
     ternfs_debug("adding inline span");
 
-    insert_span(&ctx->spans, &span->span);
+    if (!insert_span(&ctx->spans, &span->span)) {
+        ctx->err = -EIO;
+        kmem_cache_free(ternfs_inline_span_cachep, span);
+        return;
+    }
 }
 
 struct ternfs_span* ternfs_get_span(struct ternfs_fs_info* fs_info, struct ternfs_file_spans* spans, u64 offset) {
@@ -1081,7 +1099,7 @@ int ternfs_span_init(void) {
         sizeof(((struct ternfs_inline_span*)NULL)->body),
         NULL
     );
-    if (!ternfs_block_span_cachep) {
+    if (!ternfs_inline_span_cachep) {
         err = -ENOMEM;
         goto out_block;
     }


### PR DESCRIPTION
The kernel allocator annotations do not identify their matching free functions, so GCC's analyzer cannot detect leaks through most kmod error paths.

Add analyzer-only allocator declarations for kmalloc, slab and vmalloc allocations. Add a separate build target which promotes allocation, deallocation and NULL-dereference findings to errors. Run it in CI after preparing the 6.14 kernel and before the normal kmod build and tests.

Fix the issues found while adding the analysis:

* handle kzalloc and vzalloc failures as NULL in debugfs setup
* unwind failed debugfs wrapper creation and free both latency wrappers
* check the inline span cache after creating it
* free rejected and duplicate spans through the correct slab cache
* mark bad-address hash insertion as an ownership transfer

