### PR TITLE
shard: validate link file names

### DIFF
--- a/cpp/shard/ShardDB.cpp
+++ b/cpp/shard/ShardDB.cpp
@@ -1129,6 +1129,9 @@ struct ShardDBImpl {
         if (req.ownerId.shard() != _shid || req.fileId.shard() != _shid) {
             return TernError::BAD_SHARD;
         }
+        if (!validName(req.name.ref())) {
+            return TernError::BAD_NAME;
+        }
         TernError err = _checkTransientFileCookie(req.fileId, req.cookie.data);
         if (err != TernError::NO_ERROR) {
             return err;

--- a/cpp/tests/tests.cpp
+++ b/cpp/tests/tests.cpp
@@ -740,6 +740,26 @@ TEST_CASE("wire request validation returns errors") {
         CHECK(db->prepareLogEntry(reqContainer, logEntry) == TernError::MALFORMED_REQUEST);
     }
 
+    SUBCASE("link file requires a valid name") {
+        const std::vector<std::string> invalidNames{
+            "",
+            ".",
+            "..",
+            "bad/name",
+            std::string("bad\0name", 8),
+        };
+        for (const auto& name : invalidNames) {
+            ShardReqContainer reqContainer;
+            ShardLogEntry logEntry;
+            auto& req = reqContainer.setLinkFile();
+            req.ownerId = ROOT_DIR_INODE_ID;
+            req.fileId = InodeId(InodeType::FILE, ShardId(0), 1);
+            req.name = name;
+
+            CHECK(db->prepareLogEntry(reqContainer, logEntry) == TernError::BAD_NAME);
+        }
+    }
+
     SUBCASE("swap blocks requires distinct files") {
         ShardReqContainer reqContainer;
         ShardLogEntry logEntry;


### PR DESCRIPTION
LINK_FILE accepted names which violate the namespace rules enforced for other edge-creation requests. NFS now filters those values, but a direct shard client could still create an invalid edge.

Validate the name before checking the transient-file cookie and return BAD_NAME for empty, reserved, slash-containing or NUL-containing names. 