### PR TITLE
go/client: return bincode packing errors

### DIFF
--- a/go/client/client.go
+++ b/go/client/client.go
@@ -1258,8 +1258,12 @@ func (c *Client) Close() {
 
 // Not atomic between the read/write
 func (c *Client) MergeDirectoryInfo(log *log.Logger, id msgs.InodeId, entry msgs.IsDirectoryInfoEntry) error {
+	body, err := bincode.Pack(entry)
+	if err != nil {
+		return fmt.Errorf("could not pack directory info entry: %w", err)
+	}
 	packedEntry := msgs.DirectoryInfoEntry{
-		Body: bincode.Pack(entry),
+		Body: body,
 		Tag:  entry.Tag(),
 	}
 	statResp := msgs.StatDirectoryResp{}

--- a/go/client/metadatareq_test.go
+++ b/go/client/metadatareq_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/XTXMarkets/ternfs/go/core/log"
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+func TestWriteRegistryRequestReturnsPackErrors(t *testing.T) {
+	logger := log.NewLogger(os.Stderr, &log.LoggerOptions{Level: log.ERROR})
+	err := writeRegistryRequest(logger, io.Discard, &msgs.UpdateBlockServicePathReq{
+		NewPath: strings.Repeat("x", 256),
+	})
+	if err == nil {
+		t.Fatal("oversized registry request packed successfully")
+	}
+}
+
+func TestMetadataRequestProcessorSurvivesPackErrors(t *testing.T) {
+	cm := clientMetadata{
+		client:   &Client{},
+		incoming: make(chan *metadataProcessorRequest),
+		inFlight: make(chan *metadataProcessorRequest, 1),
+	}
+	logger := log.NewLogger(os.Stderr, &log.LoggerOptions{Level: log.ERROR})
+	done := make(chan struct{})
+	go func() {
+		cm.processRequests(logger)
+		close(done)
+	}()
+
+	responses := make(chan *metadataProcessorResponse, 2)
+	for requestID := uint64(1); requestID <= 2; requestID++ {
+		cm.incoming <- &metadataProcessorRequest{
+			requestId: requestID,
+			timeout:   time.Second,
+			shard:     0,
+			req: &msgs.LookupReq{
+				DirId: msgs.ROOT_DIR_INODE_ID,
+				Name:  strings.Repeat("x", 256),
+			},
+			resp:   &msgs.LookupResp{},
+			respCh: responses,
+		}
+	}
+	close(cm.incoming)
+
+	for requestID := uint64(1); requestID <= 2; requestID++ {
+		response := <-responses
+		if response.requestId != requestID {
+			t.Fatalf("request id = %d, want %d", response.requestId, requestID)
+		}
+		if response.err == nil {
+			t.Fatalf("request %d unexpectedly packed", requestID)
+		}
+	}
+	<-done
+}

--- a/go/client/registryreq.go
+++ b/go/client/registryreq.go
@@ -21,7 +21,10 @@ import (
 func writeRegistryRequest(log *log.Logger, w io.Writer, req msgs.RegistryRequest) error {
 	log.Debug("sending request %v to registry", req.RegistryRequestKind())
 	// serialize
-	bytes := bincode.Pack(req)
+	bytes, err := bincode.Pack(req)
+	if err != nil {
+		return fmt.Errorf("could not pack registry request: %w", err)
+	}
 	// write out
 	if err := binary.Write(w, binary.LittleEndian, msgs.REGISTRY_REQ_PROTOCOL_VERSION); err != nil {
 		return err

--- a/go/core/bincode/bincode.go
+++ b/go/core/bincode/bincode.go
@@ -21,8 +21,8 @@ func PackScalar[V bool | uint8 | uint16 | uint32 | uint64](w io.Writer, x V) err
 }
 
 func PackBytes(w io.Writer, bs []byte) error {
-	if len(bs) > 255 {
-		panic(fmt.Sprintf("bytes length exceed 255: %v", len(bs)))
+	if len(bs) > math.MaxUint8 {
+		return fmt.Errorf("bytes length %d exceeds maximum %d", len(bs), math.MaxUint8)
 	}
 	if err := PackScalar(w, uint8(len(bs))); err != nil {
 		return err
@@ -42,8 +42,8 @@ func PackFixedBytes(w io.Writer, l int, bs []byte) error {
 }
 
 func PackLength(w io.Writer, l int) error {
-	if l > math.MaxUint16 {
-		panic(fmt.Sprintf("len %d exceeds max length %d", l, math.MaxUint16))
+	if l < 0 || l > math.MaxUint16 {
+		return fmt.Errorf("length %d is outside range 0..%d", l, math.MaxUint16)
 	}
 	return PackScalar(w, uint16(l))
 }
@@ -51,8 +51,8 @@ func PackLength(w io.Writer, l int) error {
 type Blob []byte
 
 func PackBlob(w io.Writer, bs Blob) error {
-	if len(bs) > int(^uint16(0)) {
-		panic(fmt.Sprintf("bytes length exceed %v: %v", ^uint16(0), len(bs)))
+	if len(bs) > math.MaxUint16 {
+		return fmt.Errorf("blob length %d exceeds maximum %d", len(bs), math.MaxUint16)
 	}
 	if err := PackScalar(w, uint16(len(bs))); err != nil {
 		return err
@@ -147,12 +147,12 @@ func EnsureLength[T any](xs *[]T, l int) {
 	}
 }
 
-func Pack(v Packable) []byte {
+func Pack(v Packable) ([]byte, error) {
 	buf := bytes.NewBuffer([]byte{})
 	if err := v.Pack(buf); err != nil {
-		panic(err)
+		return nil, err
 	}
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 func Unpack(data []byte, v Unpackable) error {

--- a/go/core/bincode/bincode_test.go
+++ b/go/core/bincode/bincode_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package bincode
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"testing"
+)
+
+type oversizedPackable struct{}
+
+func (oversizedPackable) Pack(w io.Writer) error {
+	return PackBytes(w, bytes.Repeat([]byte{'x'}, math.MaxUint8+1))
+}
+
+func TestPackBytesLengthBounds(t *testing.T) {
+	if err := PackBytes(io.Discard, bytes.Repeat([]byte{'x'}, math.MaxUint8)); err != nil {
+		t.Fatalf("maximum-length bytes: %v", err)
+	}
+	if err := PackBytes(io.Discard, bytes.Repeat([]byte{'x'}, math.MaxUint8+1)); err == nil {
+		t.Fatal("oversized bytes succeeded")
+	}
+}
+
+func TestPackBlobLengthBounds(t *testing.T) {
+	if err := PackBlob(io.Discard, bytes.Repeat([]byte{'x'}, math.MaxUint16)); err != nil {
+		t.Fatalf("maximum-length blob: %v", err)
+	}
+	if err := PackBlob(io.Discard, bytes.Repeat([]byte{'x'}, math.MaxUint16+1)); err == nil {
+		t.Fatal("oversized blob succeeded")
+	}
+}
+
+func TestPackLengthBounds(t *testing.T) {
+	if err := PackLength(io.Discard, math.MaxUint16); err != nil {
+		t.Fatalf("maximum length: %v", err)
+	}
+	if err := PackLength(io.Discard, math.MaxUint16+1); err == nil {
+		t.Fatal("oversized length succeeded")
+	}
+	if err := PackLength(io.Discard, -1); err == nil {
+		t.Fatal("negative length succeeded")
+	}
+}
+
+func TestPackReturnsPackingErrors(t *testing.T) {
+	if _, err := Pack(oversizedPackable{}); err == nil {
+		t.Fatal("oversized value packed successfully")
+	}
+}

--- a/go/ternregistryproxy/ternregistryproxy.go
+++ b/go/ternregistryproxy/ternregistryproxy.go
@@ -205,7 +205,10 @@ func isBenignConnTermination(err error) bool {
 
 func writeRegistryResponse(log *log.Logger, w io.Writer, resp msgs.RegistryResponse) error {
 	// serialize
-	bytes := bincode.Pack(resp)
+	bytes, err := bincode.Pack(resp)
+	if err != nil {
+		return fmt.Errorf("could not pack registry response: %w", err)
+	}
 	// write out
 	if err := binary.Write(w, binary.LittleEndian, msgs.REGISTRY_RESP_PROTOCOL_VERSION); err != nil {
 		return err


### PR DESCRIPTION
`go/client` serializes caller-supplied values through generated bincode packers. The variable-length packers and Pack helper panicked when a value did not fit its wire format. This terminated the process instead of returning an error to the caller.
    
This PR changes `PackBytes`, `PackBlob` and `PackLength` to return errors in the standard go style. Update `ternregistryproxy` to use the new interface.

The old API is intentionally not preserved to force external clients to update.
