### PR TITLE
client/terncli: add cancellable recursive grep

### DIFF
--- a/go/cleanup/defrag.go
+++ b/go/cleanup/defrag.go
@@ -8,6 +8,7 @@
 package cleanup
 
 import (
+	"context"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/cleanup/scratch"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -210,8 +211,10 @@ func DefragFiles(
 	root string,
 ) error {
 	timeStats := newTimeStats()
-	return client.Parwalk(
-		log, c, &client.ParwalkOptions{WorkersPerShard: options.WorkersPerShard}, root,
+	pool := client.NewParwalkPool(log, c, options.WorkersPerShard)
+	defer pool.Close()
+	return pool.Walk(
+		context.Background(), &client.ParwalkOptions{}, root,
 		func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {
 			if id.Type() == msgs.DIRECTORY {
 				return nil
@@ -325,8 +328,10 @@ func DefragSpans(
 	root string,
 ) error {
 	timeStats := newTimeStats()
-	return client.Parwalk(
-		log, c, &client.ParwalkOptions{WorkersPerShard: 5}, root,
+	pool := client.NewParwalkPool(log, c, 5)
+	defer pool.Close()
+	return pool.Walk(
+		context.Background(), &client.ParwalkOptions{}, root,
 		func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {
 			if id.Type() == msgs.DIRECTORY {
 				return nil

--- a/go/client/grep.go
+++ b/go/client/grep.go
@@ -1,0 +1,190 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"regexp"
+
+	"github.com/XTXMarkets/ternfs/go/core/bufpool"
+	"github.com/XTXMarkets/ternfs/go/core/log"
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+const defaultGrepMaxLineSize = 1024 * 1024
+
+// grepReadBufferSize is large enough that virtually every line comes back
+// from ReadSlice as a single zero-copy fragment.
+const grepReadBufferSize = 1 << 20
+
+// ErrGrepLineTooLong reports a file containing a line over MaxLineSize.
+var ErrGrepLineTooLong = errors.New("grep line is too long")
+
+// ErrGrepFileTooLarge reports a file over MaxFileSize.
+var ErrGrepFileTooLarge = errors.New("grep file is too large")
+
+// GrepMatch describes the first match on one line. ByteOffset is the
+// offset of the match within the file, not the offset of the line.
+type GrepMatch struct {
+	Path       string
+	Inode      msgs.InodeId
+	LineNumber uint64
+	ByteOffset uint64
+	Line       string
+}
+
+// GrepFile searches one file for pattern, invoking onMatch for the first
+// match on each matching line, and returns the number of bytes read. A
+// maxFileSize of zero is unlimited; a maxLineSize <= 0 uses a sensible
+// default. Size-limit errors wrap ErrGrepFileTooLarge or
+// ErrGrepLineTooLong and should be tested with errors.Is. Cancelling ctx
+// or returning an error from onMatch stops the scan early. Callers that drive
+// their own traversal can use this directly instead of RecursiveGrep.Grep.
+func GrepFile(
+	ctx context.Context,
+	logger *log.Logger,
+	client *Client,
+	bufPool *bufpool.BufPool,
+	filePath string,
+	id msgs.InodeId,
+	pattern *regexp.Regexp,
+	maxFileSize uint64,
+	maxLineSize int,
+	onMatch func(GrepMatch) error,
+) (uint64, error) {
+	if maxLineSize <= 0 {
+		maxLineSize = defaultGrepMaxLineSize
+	}
+	reader, err := client.ReadFile(
+		logger,
+		bufPool,
+		id,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if maxFileSize > 0 {
+		size, seekErr := reader.Seek(0, io.SeekEnd)
+		if seekErr == nil {
+			_, seekErr = reader.Seek(0, io.SeekStart)
+		}
+		if seekErr != nil {
+			return 0, errors.Join(seekErr, reader.Close())
+		}
+		if uint64(size) > maxFileSize {
+			return 0, errors.Join(ErrGrepFileTooLarge, reader.Close())
+		}
+	}
+	bytesScanned, err := scanGrepReader(
+		ctx,
+		reader,
+		pattern,
+		maxLineSize,
+		func(
+			lineNumber uint64,
+			byteOffset uint64,
+			line []byte,
+		) error {
+			return onMatch(GrepMatch{
+				Path:       filePath,
+				Inode:      id,
+				LineNumber: lineNumber,
+				ByteOffset: byteOffset,
+				Line:       string(line),
+			})
+		},
+	)
+	closeErr := reader.Close()
+	if err == nil {
+		err = closeErr
+	}
+	return bytesScanned, err
+}
+
+type grepContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (reader grepContextReader) Read(p []byte) (int, error) {
+	if err := context.Cause(reader.ctx); err != nil {
+		return 0, err
+	}
+	return reader.reader.Read(p)
+}
+
+// scanGrepReader reads reader line by line and invokes match for the
+// first pattern match on each line. The line slice passed to match aliases
+// the internal read buffer and is invalidated by the next match call, so
+// implementations must copy it if they need to retain it (GrepFile
+// converts it to a string for exactly this reason).
+func scanGrepReader(
+	ctx context.Context,
+	reader io.Reader,
+	pattern *regexp.Regexp,
+	maxLineSize int,
+	match func(lineNumber uint64, byteOffset uint64, line []byte) error,
+) (uint64, error) {
+	buffered := bufio.NewReaderSize(
+		grepContextReader{ctx: ctx, reader: reader},
+		grepReadBufferSize,
+	)
+	var bytesScanned uint64
+	for lineNumber := uint64(1); ; lineNumber++ {
+		lineStart := bytesScanned
+		line, rawSize, err := readGrepLine(buffered, maxLineSize)
+		bytesScanned += uint64(rawSize)
+		if len(line) > 0 && (err == nil || errors.Is(err, io.EOF)) {
+			text := bytes.TrimSuffix(line, []byte{'\n'})
+			text = bytes.TrimSuffix(text, []byte{'\r'})
+			if location := pattern.FindIndex(text); location != nil {
+				if emitErr := match(
+					lineNumber,
+					lineStart+uint64(location[0]),
+					text,
+				); emitErr != nil {
+					return bytesScanned, emitErr
+				}
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return bytesScanned, nil
+		}
+		if err != nil {
+			return bytesScanned, err
+		}
+	}
+}
+
+// readGrepLine returns one line, including the trailing newline. When the
+// whole line fits in the read buffer -- the common case -- the result is
+// ReadSlice's zero-copy view of that buffer; only a line spanning a buffer
+// refill is copied into a fresh allocation.
+func readGrepLine(
+	reader *bufio.Reader,
+	maxLineSize int,
+) ([]byte, int, error) {
+	var line []byte
+	rawSize := 0
+	for {
+		fragment, err := reader.ReadSlice('\n')
+		rawSize += len(fragment)
+		if rawSize > maxLineSize {
+			return nil, rawSize, ErrGrepLineTooLong
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			line = append(line, fragment...)
+			continue
+		}
+		if line == nil {
+			return fragment, rawSize, err
+		}
+		return append(line, fragment...), rawSize, err
+	}
+}

--- a/go/client/grep_test.go
+++ b/go/client/grep_test.go
@@ -1,0 +1,265 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestScanGrepReader(t *testing.T) {
+	const contents = "zero\nfoo one\r\nmiddle foo end\nlast foo"
+	type foundMatch struct {
+		lineNumber uint64
+		byteOffset uint64
+		line       string
+	}
+	var matches []foundMatch
+	bytesScanned, err := scanGrepReader(
+		context.Background(),
+		strings.NewReader(contents),
+		regexp.MustCompile("foo"),
+		1024,
+		func(lineNumber uint64, byteOffset uint64, line []byte) error {
+			matches = append(matches, foundMatch{
+				lineNumber: lineNumber,
+				byteOffset: byteOffset,
+				line:       string(line),
+			})
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytesScanned != uint64(len(contents)) {
+		t.Fatalf("bytes scanned = %d, want %d", bytesScanned, len(contents))
+	}
+	want := []foundMatch{
+		{lineNumber: 2, byteOffset: 5, line: "foo one"},
+		{lineNumber: 3, byteOffset: 21, line: "middle foo end"},
+		{lineNumber: 4, byteOffset: 34, line: "last foo"},
+	}
+	if len(matches) != len(want) {
+		t.Fatalf("matches = %#v, want %#v", matches, want)
+	}
+	for i := range want {
+		if matches[i] != want[i] {
+			t.Fatalf("match %d = %#v, want %#v", i, matches[i], want[i])
+		}
+	}
+}
+
+func TestScanGrepReaderEmitsOncePerLine(t *testing.T) {
+	var matches int
+	_, err := scanGrepReader(
+		context.Background(),
+		strings.NewReader("foo foo\n"),
+		regexp.MustCompile("foo"),
+		1024,
+		func(_ uint64, byteOffset uint64, _ []byte) error {
+			matches++
+			if byteOffset != 0 {
+				t.Fatalf("byte offset = %d, want 0", byteOffset)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matches != 1 {
+		t.Fatalf("matches = %d, want 1", matches)
+	}
+}
+
+func TestScanGrepReaderRejectsLongLine(t *testing.T) {
+	bytesScanned, err := scanGrepReader(
+		context.Background(),
+		strings.NewReader("12345\n"),
+		regexp.MustCompile("."),
+		4,
+		func(uint64, uint64, []byte) error {
+			t.Fatal("match callback was called")
+			return nil
+		},
+	)
+	if !errors.Is(err, ErrGrepLineTooLong) {
+		t.Fatalf("error = %v, want %v", err, ErrGrepLineTooLong)
+	}
+	if bytesScanned != 6 {
+		t.Fatalf("bytes scanned = %d, want 6", bytesScanned)
+	}
+}
+
+var errGrepRead = errors.New("read failed")
+
+type failingGrepReader struct {
+	contents string
+}
+
+func (reader *failingGrepReader) Read(p []byte) (int, error) {
+	n := copy(p, reader.contents)
+	reader.contents = reader.contents[n:]
+	return n, errGrepRead
+}
+
+func TestScanGrepReaderDoesNotMatchPartialLineBeforeError(t *testing.T) {
+	bytesScanned, err := scanGrepReader(
+		context.Background(),
+		&failingGrepReader{contents: "partial foo"},
+		regexp.MustCompile("foo"),
+		1024,
+		func(uint64, uint64, []byte) error {
+			t.Fatal("match callback was called")
+			return nil
+		},
+	)
+	if !errors.Is(err, errGrepRead) {
+		t.Fatalf("error = %v, want %v", err, errGrepRead)
+	}
+	if bytesScanned != uint64(len("partial foo")) {
+		t.Fatalf("bytes scanned = %d, want %d", bytesScanned, len("partial foo"))
+	}
+}
+
+func TestScanGrepReaderCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	bytesScanned, err := scanGrepReader(
+		ctx,
+		strings.NewReader("foo\n"),
+		regexp.MustCompile("foo"),
+		1024,
+		func(uint64, uint64, []byte) error {
+			t.Fatal("match callback was called")
+			return nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want %v", err, context.Canceled)
+	}
+	if bytesScanned != 0 {
+		t.Fatalf("bytes scanned = %d, want 0", bytesScanned)
+	}
+}
+
+type cancelAfterFirstRead struct {
+	reader io.Reader
+	cancel context.CancelFunc
+	read   bool
+}
+
+func (reader *cancelAfterFirstRead) Read(p []byte) (int, error) {
+	n, err := reader.reader.Read(p)
+	if !reader.read {
+		reader.read = true
+		reader.cancel()
+	}
+	return n, err
+}
+
+func TestScanGrepReaderCancellationBetweenBufferRefills(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	contents := strings.Repeat("a", grepReadBufferSize+1)
+	reader := &cancelAfterFirstRead{
+		reader: strings.NewReader(contents),
+		cancel: cancel,
+	}
+
+	bytesScanned, err := scanGrepReader(
+		ctx,
+		reader,
+		regexp.MustCompile("needle"),
+		len(contents),
+		func(uint64, uint64, []byte) error {
+			t.Fatal("match callback was called")
+			return nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want %v", err, context.Canceled)
+	}
+	if bytesScanned != grepReadBufferSize {
+		t.Fatalf(
+			"bytes scanned = %d, want %d",
+			bytesScanned,
+			grepReadBufferSize,
+		)
+	}
+}
+
+func TestScanGrepReaderPropagatesMatchError(t *testing.T) {
+	matchErr := errors.New("stop")
+	_, err := scanGrepReader(
+		context.Background(),
+		strings.NewReader("foo\n"),
+		regexp.MustCompile("foo"),
+		1024,
+		func(uint64, uint64, []byte) error {
+			return matchErr
+		},
+	)
+	if !errors.Is(err, matchErr) {
+		t.Fatalf("error = %v, want %v", err, matchErr)
+	}
+}
+
+func TestScanGrepReaderFragmentedLine(t *testing.T) {
+	// A line longer than the read buffer, forcing the fragmented path.
+	longLine := strings.Repeat("a", grepReadBufferSize+500_000)
+	contents := "before\n" + longLine + " needle\nafter\n"
+	var matched []string
+	bytesScanned, err := scanGrepReader(
+		context.Background(),
+		strings.NewReader(contents),
+		regexp.MustCompile("needle"),
+		2*grepReadBufferSize,
+		func(lineNumber uint64, byteOffset uint64, line []byte) error {
+			if lineNumber != 2 {
+				t.Fatalf("match on line %d, want 2", lineNumber)
+			}
+			matched = append(matched, string(line))
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytesScanned != uint64(len(contents)) {
+		t.Fatalf("bytes scanned = %d, want %d", bytesScanned, len(contents))
+	}
+	if len(matched) != 1 {
+		t.Fatalf("matches = %d, want 1", len(matched))
+	}
+	if !strings.HasSuffix(matched[0], " needle") || len(matched[0]) != len(longLine)+7 {
+		t.Fatalf("matched line has length %d, want %d", len(matched[0]), len(longLine)+7)
+	}
+}
+
+func BenchmarkScanGrepReader(b *testing.B) {
+	line := "the quick brown fox jumps over the lazy dog\n"
+	contents := strings.Repeat(line, 1<<20/len(line)) + "needle\n"
+	pattern := regexp.MustCompile("needle")
+	b.SetBytes(int64(len(contents)))
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := scanGrepReader(
+			context.Background(),
+			strings.NewReader(contents),
+			pattern,
+			defaultGrepMaxLineSize,
+			func(uint64, uint64, []byte) error { return nil },
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/go/client/parwalk.go
+++ b/go/client/parwalk.go
@@ -9,12 +9,11 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
-	"sync"
 
-	"github.com/XTXMarkets/ternfs/go/core/log"
 	"github.com/XTXMarkets/ternfs/go/msgs"
 )
 
@@ -23,22 +22,24 @@ import (
 // for a non-directory entry is harmless -- there's nothing to skip.
 var ErrSkipSubtree = errors.New("parwalk: skip subtree")
 
-type parwarlkReq struct {
-	id   msgs.InodeId
-	path string
-}
+// ParwalkVisitFunc is invoked for every edge visited by a ParwalkPool. Callers
+// that need cancellation inside the visit function should close over the context
+// passed to Walk, WalkMany, or WalkFromInode.
+type ParwalkVisitFunc func(
+	parent msgs.InodeId,
+	parentPath string,
+	name string,
+	creationTime msgs.TernTime,
+	id msgs.InodeId,
+	current bool,
+	owned bool,
+) error
 
-type parwalkEnv struct {
-	wg             sync.WaitGroup
-	chans          []chan parwarlkReq
-	client         *Client
-	snapshot       bool
-	snapshotLatest bool
-	callback       func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error
-}
-
-func (env *parwalkEnv) visit(
-	log *log.Logger,
+// visitAndRecurse invokes the run's onEdge callback for one edge, and then,
+// if the edge points at an owned directory, recurses into it -- inline on the
+// current goroutine when the directory lives on the same shard, otherwise by
+// scheduling it on the owning shard's workers.
+func (run *parwalkRun) visitAndRecurse(
 	homeShid msgs.ShardId,
 	parent msgs.InodeId,
 	parentPath string,
@@ -48,7 +49,18 @@ func (env *parwalkEnv) visit(
 	current bool,
 	owned bool,
 ) error {
-	cbErr := env.callback(parent, parentPath, name, creationTime, id, current, owned)
+	if err := run.cause(); err != nil {
+		return err
+	}
+	cbErr := run.onEdge(
+		parent,
+		parentPath,
+		name,
+		creationTime,
+		id,
+		current,
+		owned,
+	)
 	if errors.Is(cbErr, ErrSkipSubtree) {
 		return nil
 	}
@@ -60,62 +72,54 @@ func (env *parwalkEnv) visit(
 		return nil
 	}
 	// if it's not owned, skip
-	if !owned && !env.snapshot {
+	if !owned && !run.Snapshot {
 		return nil
 	}
 	fullPath := path.Join(parentPath, name)
 	if parent != msgs.NULL_INODE_ID && homeShid == id.Shard() {
 		// same shard, handle right now
-		env.process(log, homeShid, id, fullPath)
-	} else {
-		req := parwarlkReq{
-			id:   id,
-			path: fullPath,
-		}
-		select {
-		// pass to other shard
-		case env.chans[id.Shard()] <- req:
-			env.wg.Add(1)
-		// queue is full, do it yourself
-		default:
-			env.process(log, homeShid, id, fullPath)
-		}
+		return run.process(homeShid, id, fullPath)
 	}
-	return nil
+	return run.schedule(homeShid, id, fullPath)
 }
 
-func (env *parwalkEnv) process(
-	log *log.Logger,
+func (run *parwalkRun) process(
 	homeShid msgs.ShardId,
 	id msgs.InodeId,
 	pathStr string,
 ) error {
-	if env.snapshotLatest {
-		return env.processSnapshotLatest(log, homeShid, id, pathStr)
+	if err := run.cause(); err != nil {
+		return err
 	}
-	if env.snapshot {
+	if run.SnapshotLatest {
+		return run.processSnapshotLatest(homeShid, id, pathStr)
+	}
+	if run.Snapshot {
 		cursor := msgs.FullReadDirCursor{}
 		for {
+			if err := run.cause(); err != nil {
+				return err
+			}
 			flags := msgs.FullReadDirFlags(0)
 			if cursor.Current {
 				flags = msgs.FULL_READ_DIR_CURRENT
 			}
-			resp, err := env.client.fullReadDir(
-				log,
+			resp, err := run.pool.client.fullReadDir(
+				run.pool.log,
 				id,
 				flags,
 				cursor.StartName,
 				cursor.StartTime,
 			)
 			if err != nil {
-				log.Debug("failed to read dir %v at path %q, it might have been deleted in the meantime: %v", id, pathStr, err)
+				run.pool.log.Debug("failed to read dir %v at path %q, it might have been deleted in the meantime: %v", id, pathStr, err)
 				return nil
 			}
 			for _, e := range resp.Results {
 				if e.TargetId.Id() == msgs.NULL_INODE_ID { // no point looking at deletion edges
 					continue
 				}
-				if err := env.visit(log, homeShid, id, pathStr, e.Name, e.CreationTime, e.TargetId.Id(), e.Current, e.Current || e.TargetId.Extra()); err != nil {
+				if err := run.visitAndRecurse(homeShid, id, pathStr, e.Name, e.CreationTime, e.TargetId.Id(), e.Current, e.Current || e.TargetId.Extra()); err != nil {
 					return err
 				}
 			}
@@ -130,12 +134,15 @@ func (env *parwalkEnv) process(
 		}
 		readResp := &msgs.ReadDirResp{}
 		for {
-			if err := env.client.ShardRequest(log, id.Shard(), readReq, readResp); err != nil {
-				log.Debug("failed to read dir %v at path %q, it might have been deleted in the meantime: %v", id, pathStr, err)
+			if err := run.cause(); err != nil {
+				return err
+			}
+			if err := run.pool.client.ShardRequest(run.pool.log, id.Shard(), readReq, readResp); err != nil {
+				run.pool.log.Debug("failed to read dir %v at path %q, it might have been deleted in the meantime: %v", id, pathStr, err)
 				return nil
 			}
 			for _, e := range readResp.Results {
-				if err := env.visit(log, homeShid, id, pathStr, e.Name, e.CreationTime, e.TargetId, true, true); err != nil {
+				if err := run.visitAndRecurse(homeShid, id, pathStr, e.Name, e.CreationTime, e.TargetId, true, true); err != nil {
 					return err
 				}
 			}
@@ -150,8 +157,7 @@ func (env *parwalkEnv) process(
 
 // processSnapshotLatest reads all snapshot edges of a directory newest-first
 // and keeps, per name, the newest edge whose target is not NULL.
-func (env *parwalkEnv) processSnapshotLatest(
-	log *log.Logger,
+func (run *parwalkRun) processSnapshotLatest(
 	homeShid msgs.ShardId,
 	id msgs.InodeId,
 	pathStr string,
@@ -165,19 +171,22 @@ func (env *parwalkEnv) processSnapshotLatest(
 	latest := map[string]latestEdge{}
 	cursor := msgs.FullReadDirCursor{}
 	for {
+		if err := run.cause(); err != nil {
+			return err
+		}
 		flags := msgs.FULL_READ_DIR_BACKWARDS
 		if cursor.Current {
 			flags |= msgs.FULL_READ_DIR_CURRENT
 		}
-		resp, err := env.client.fullReadDir(
-			log,
+		resp, err := run.pool.client.fullReadDir(
+			run.pool.log,
 			id,
 			flags,
 			cursor.StartName,
 			cursor.StartTime,
 		)
 		if err != nil {
-			log.Debug("failed to read dir %v at path %q, it might have been deleted in the meantime: %v", id, pathStr, err)
+			run.pool.log.Debug("failed to read dir %v at path %q, it might have been deleted in the meantime: %v", id, pathStr, err)
 			return nil
 		}
 		for _, e := range resp.Results {
@@ -200,7 +209,7 @@ func (env *parwalkEnv) processSnapshotLatest(
 		cursor = resp.Next
 	}
 	for name, e := range latest {
-		if err := env.visit(log, homeShid, id, pathStr, name, e.creationTime, e.targetId, e.current, e.owned); err != nil {
+		if err := run.visitAndRecurse(homeShid, id, pathStr, name, e.creationTime, e.targetId, e.current, e.owned); err != nil {
 			return err
 		}
 	}
@@ -208,8 +217,7 @@ func (env *parwalkEnv) processSnapshotLatest(
 }
 
 type ParwalkOptions struct {
-	WorkersPerShard int
-	Snapshot        bool
+	Snapshot bool
 	// SnapshotLatest, when true, iterates snapshot edges backwards (newest
 	// first) and invokes the callback only for the newest non-null edge per
 	// name. NULL (deletion) edges are ignored. Implies Snapshot=true. Useful
@@ -217,63 +225,124 @@ type ParwalkOptions struct {
 	SnapshotLatest bool
 }
 
-// Parwalk traverses the subtree rooted at `root` (a path), invoking callback
-// for each edge it visits. See ParwalkFromInode for a variant that starts
-// from an inode id (useful when the root has no live path, e.g. a deleted
-// directory).
-func Parwalk(
-	log *log.Logger,
-	client *Client,
+// normalized returns the options as a value, folding SnapshotLatest's implied
+// Snapshot into it.
+func (options *ParwalkOptions) normalized() ParwalkOptions {
+	if options == nil {
+		return ParwalkOptions{}
+	}
+	normalized := *options
+	normalized.Snapshot = normalized.Snapshot || normalized.SnapshotLatest
+	return normalized
+}
+
+// parwalkSeed is one root edge of a walk: the edge leading from the root's
+// parent to the root itself.
+type parwalkSeed struct {
+	parentId     msgs.InodeId
+	parentPath   string
+	name         string
+	creationTime msgs.TernTime
+	rootId       msgs.InodeId
+}
+
+func parwalkRunWithSeeds(
+	pool *ParwalkPool,
+	ctx context.Context,
+	options ParwalkOptions,
+	onEdge ParwalkVisitFunc,
+	seeds []parwalkSeed,
+) error {
+	prime := func(run *parwalkRun) error {
+		for _, seed := range seeds {
+			if err := run.visitAndRecurse(
+				0,
+				seed.parentId,
+				seed.parentPath,
+				seed.name,
+				seed.creationTime,
+				seed.rootId,
+				true,
+				true,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return pool.run(ctx, prime, onEdge, options)
+}
+
+// Walk traverses one path using the shared workers.
+func (pool *ParwalkPool) Walk(
+	ctx context.Context,
 	options *ParwalkOptions,
 	root string,
-	callback func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error,
+	onEdge ParwalkVisitFunc,
 ) error {
-	rootId, creationTime, parentId, err := client.ResolvePathWithParent(log, root)
-	if err != nil {
+	if err := context.Cause(ctx); err != nil {
 		return err
 	}
-	return parwalkRunWithSeeds(log, client, options, callback, []parwalkSeed{
-		{parentId: parentId, parentPath: path.Dir(root), name: path.Base(root), creationTime: creationTime, rootId: rootId},
+	rootId, creationTime, parentId, err :=
+		pool.client.ResolvePathWithParent(pool.log, root)
+	if err != nil {
+		return fmt.Errorf("resolve %q: %w", root, err)
+	}
+	return parwalkRunWithSeeds(pool, ctx, options.normalized(), onEdge, []parwalkSeed{
+		{
+			parentId:     parentId,
+			parentPath:   path.Dir(root),
+			name:         path.Base(root),
+			creationTime: creationTime,
+			rootId:       rootId,
+		},
 	})
 }
 
-// ParwalkFromInode is like Parwalk but takes an inode id as the root instead
+// WalkFromInode is like Walk but takes an inode id as the root instead
 // of a path. `rootPath` is a cookie passed through to the callback as the
 // parentPath of the root's children; it is not resolved against the
 // filesystem, so callers may pass any string meaningful to their callback
 // (e.g. a destination path when walking a deleted subtree to reconstruct it
 // somewhere else).
-func ParwalkFromInode(
-	log *log.Logger,
-	client *Client,
+func (pool *ParwalkPool) WalkFromInode(
+	ctx context.Context,
 	options *ParwalkOptions,
 	rootId msgs.InodeId,
 	rootPath string,
-	callback func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error,
+	onEdge ParwalkVisitFunc,
 ) error {
-	return parwalkRunWithSeeds(log, client, options, callback, []parwalkSeed{
-		{parentId: msgs.NULL_INODE_ID, parentPath: path.Dir(rootPath), name: path.Base(rootPath), creationTime: 0, rootId: rootId},
+	return parwalkRunWithSeeds(pool, ctx, options.normalized(), onEdge, []parwalkSeed{
+		{
+			parentId:   msgs.NULL_INODE_ID,
+			parentPath: path.Dir(rootPath),
+			name:       path.Base(rootPath),
+			rootId:     rootId,
+		},
 	})
 }
 
-// ParwalkMany walks several roots through a single shared 256×WorkersPerShard
+// WalkMany walks several roots through a single shared 256×WorkersPerShard
 // goroutine pool. Roots are resolved up front (so a typo in any root fails
 // fast) and then seeded one after another into the same pool, so the workers
 // servicing one shard process edges from every root concurrently rather than
 // idling between roots.
 //
-// The callback contract is identical to Parwalk; callers that want to know
+// The visit contract is identical to Walk; callers that want to know
 // which root an edge belongs to can derive it from the parentPath argument.
-func ParwalkMany(
-	log *log.Logger,
-	client *Client,
+func (pool *ParwalkPool) WalkMany(
+	ctx context.Context,
 	options *ParwalkOptions,
 	roots []string,
-	callback func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error,
+	onEdge ParwalkVisitFunc,
 ) error {
 	seeds := make([]parwalkSeed, 0, len(roots))
 	for _, root := range roots {
-		rootId, creationTime, parentId, err := client.ResolvePathWithParent(log, root)
+		if err := context.Cause(ctx); err != nil {
+			return err
+		}
+		rootId, creationTime, parentId, err :=
+			pool.client.ResolvePathWithParent(pool.log, root)
 		if err != nil {
 			return fmt.Errorf("resolve %q: %w", root, err)
 		}
@@ -285,71 +354,5 @@ func ParwalkMany(
 			rootId:       rootId,
 		})
 	}
-	return parwalkRunWithSeeds(log, client, options, callback, seeds)
-}
-
-type parwalkSeed struct {
-	parentId     msgs.InodeId
-	parentPath   string
-	name         string
-	creationTime msgs.TernTime
-	rootId       msgs.InodeId
-}
-
-func parwalkRunWithSeeds(
-	log *log.Logger,
-	client *Client,
-	options *ParwalkOptions,
-	callback func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error,
-	seeds []parwalkSeed,
-) error {
-	if options.WorkersPerShard < 1 {
-		panic(fmt.Errorf("workersPerShard=%d < 1", options.WorkersPerShard))
-	}
-	env := parwalkEnv{
-		chans:          make([]chan parwarlkReq, 256),
-		client:         client,
-		callback:       callback,
-		snapshot:       options.Snapshot || options.SnapshotLatest,
-		snapshotLatest: options.SnapshotLatest,
-	}
-	for i := 0; i < 256; i++ {
-		env.chans[i] = make(chan parwarlkReq, 10_000)
-	}
-	errChan := make(chan error, 1)
-	for i := 0; i < 256; i++ {
-		shid := msgs.ShardId(i)
-		ch := env.chans[shid]
-		for j := 0; j < options.WorkersPerShard; j++ {
-			go func() {
-				for {
-					req, more := <-ch
-					if !more {
-						return
-					}
-					if err := env.process(log, shid, req.id, req.path); err != nil {
-						for _, ch := range env.chans {
-							close(ch)
-						}
-						select {
-						case errChan <- err:
-						default:
-						}
-						return
-					}
-					env.wg.Done()
-				}
-			}()
-		}
-	}
-	for _, s := range seeds {
-		if err := env.visit(log, 0, s.parentId, s.parentPath, s.name, s.creationTime, s.rootId, true, true); err != nil {
-			return err
-		}
-	}
-	go func() {
-		env.wg.Wait()
-		errChan <- nil
-	}()
-	return <-errChan
+	return parwalkRunWithSeeds(pool, ctx, options.normalized(), onEdge, seeds)
 }

--- a/go/client/parwalk_pool.go
+++ b/go/client/parwalk_pool.go
@@ -1,0 +1,176 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/XTXMarkets/ternfs/go/core/log"
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+// ErrParwalkPoolClosed is returned when a walk is submitted after the pool
+// was closed.
+var ErrParwalkPoolClosed = errors.New("parwalk pool is closed")
+
+type parwalkReq struct {
+	run  *parwalkRun
+	id   msgs.InodeId
+	path string
+}
+
+// ParwalkPool owns shard-aware directory workers shared by concurrent walks.
+type ParwalkPool struct {
+	log       *log.Logger
+	client    *Client
+	chans     []chan parwalkReq
+	workers   sync.WaitGroup
+	active    sync.WaitGroup
+	mutex     sync.Mutex
+	closed    bool
+	closeOnce sync.Once
+}
+
+type parwalkRun struct {
+	ParwalkOptions
+	pool    *ParwalkPool
+	ctx     context.Context
+	cancel  context.CancelCauseFunc
+	onEdge  ParwalkVisitFunc
+	pending sync.WaitGroup
+}
+
+// NewParwalkPool creates a shard-aware worker pool. Close must be called after
+// the final walk.
+func NewParwalkPool(
+	logger *log.Logger,
+	client *Client,
+	workersPerShard int,
+) *ParwalkPool {
+	if workersPerShard < 1 {
+		panic(fmt.Errorf("workersPerShard=%d < 1", workersPerShard))
+	}
+	pool := &ParwalkPool{
+		log:    logger,
+		client: client,
+		chans:  make([]chan parwalkReq, 256),
+	}
+	for i := range pool.chans {
+		pool.chans[i] = make(chan parwalkReq, 10_000)
+		shid := msgs.ShardId(i)
+		for range workersPerShard {
+			pool.workers.Add(1)
+			go pool.worker(shid, pool.chans[i])
+		}
+	}
+	return pool
+}
+
+func (pool *ParwalkPool) worker(
+	homeShid msgs.ShardId,
+	requests <-chan parwalkReq,
+) {
+	defer pool.workers.Done()
+	for req := range requests {
+		if context.Cause(req.run.ctx) == nil {
+			if err := req.run.process(homeShid, req.id, req.path); err != nil {
+				req.run.fail(err)
+			}
+		}
+		req.run.pending.Done()
+	}
+}
+
+// Close waits for active walks and then stops the workers. Callers must cancel
+// their walk contexts before closing a pool with active work.
+func (pool *ParwalkPool) Close() {
+	pool.closeOnce.Do(func() {
+		pool.mutex.Lock()
+		pool.closed = true
+		pool.mutex.Unlock()
+
+		pool.active.Wait()
+		for _, requests := range pool.chans {
+			close(requests)
+		}
+		pool.workers.Wait()
+	})
+}
+
+// run executes one walk on the pool's shared workers. prime seeds the walk
+// (typically one visitAndRecurse call per root); it runs before the walk is
+// awaited, so seeds that fail immediately still report through the returned
+// error.
+func (pool *ParwalkPool) run(
+	ctx context.Context,
+	prime func(*parwalkRun) error,
+	onEdge ParwalkVisitFunc,
+	options ParwalkOptions,
+) error {
+	runCtx, cancel := context.WithCancelCause(ctx)
+	run := &parwalkRun{
+		ParwalkOptions: options,
+		pool:           pool,
+		ctx:            runCtx,
+		cancel:         cancel,
+		onEdge:         onEdge,
+	}
+
+	pool.mutex.Lock()
+	if pool.closed {
+		pool.mutex.Unlock()
+		cancel(ErrParwalkPoolClosed)
+		return ErrParwalkPoolClosed
+	}
+	pool.active.Add(1)
+	pool.mutex.Unlock()
+
+	defer func() {
+		run.cancel(nil)
+		pool.active.Done()
+	}()
+
+	if err := prime(run); err != nil {
+		run.fail(err)
+	}
+	run.pending.Wait()
+	return context.Cause(run.ctx)
+}
+
+func (run *parwalkRun) cause() error {
+	return context.Cause(run.ctx)
+}
+
+func (run *parwalkRun) fail(err error) {
+	if err != nil {
+		run.cancel(err)
+	}
+}
+
+func (run *parwalkRun) schedule(
+	homeShid msgs.ShardId,
+	id msgs.InodeId,
+	pathStr string,
+) error {
+	if err := context.Cause(run.ctx); err != nil {
+		return err
+	}
+	req := parwalkReq{run: run, id: id, path: pathStr}
+	run.pending.Add(1)
+	select {
+	case <-run.ctx.Done():
+		run.pending.Done()
+		return context.Cause(run.ctx)
+	case run.pool.chans[id.Shard()] <- req:
+		return nil
+	default:
+		err := run.process(homeShid, id, pathStr)
+		run.pending.Done()
+		return err
+	}
+}

--- a/go/client/parwalk_pool_test.go
+++ b/go/client/parwalk_pool_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestParwalkPoolRun(t *testing.T) {
+	pool := NewParwalkPool(nil, nil, 1)
+	defer pool.Close()
+
+	var called bool
+	err := pool.run(
+		context.Background(),
+		func(run *parwalkRun) error {
+			called = true
+			if run.pool != pool {
+				t.Fatal("run was not attached to pool")
+			}
+			if err := context.Cause(run.ctx); err != nil {
+				t.Fatalf("run context: %v", err)
+			}
+			return nil
+		},
+		nil,
+		ParwalkOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("run function was not called")
+	}
+}
+
+func TestParwalkPoolReusedAfterRunError(t *testing.T) {
+	pool := NewParwalkPool(nil, nil, 1)
+	defer pool.Close()
+
+	runErr := errors.New("run failed")
+	err := pool.run(
+		context.Background(),
+		func(*parwalkRun) error {
+			return runErr
+		},
+		nil,
+		ParwalkOptions{},
+	)
+	if !errors.Is(err, runErr) {
+		t.Fatalf("first run error = %v, want %v", err, runErr)
+	}
+
+	err = pool.run(
+		context.Background(),
+		func(*parwalkRun) error {
+			return nil
+		},
+		nil,
+		ParwalkOptions{},
+	)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+}
+
+func TestParwalkPoolCallerCancelsActiveRun(t *testing.T) {
+	pool := NewParwalkPool(nil, nil, 1)
+	defer pool.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	done := make(chan error)
+
+	go func() {
+		done <- pool.run(
+			ctx,
+			func(run *parwalkRun) error {
+				close(started)
+				<-run.ctx.Done()
+				return context.Cause(run.ctx)
+			},
+			nil,
+			ParwalkOptions{},
+		)
+	}()
+
+	<-started
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestParwalkPoolRejectsRunAfterClose(t *testing.T) {
+	pool := NewParwalkPool(nil, nil, 1)
+	pool.Close()
+
+	called := false
+	err := pool.run(
+		context.Background(),
+		func(*parwalkRun) error {
+			called = true
+			return nil
+		},
+		nil,
+		ParwalkOptions{},
+	)
+	if !errors.Is(err, ErrParwalkPoolClosed) {
+		t.Fatalf("run error = %v, want %v", err, ErrParwalkPoolClosed)
+	}
+	if called {
+		t.Fatal("run function was called after pool close")
+	}
+}
+
+func TestParwalkPoolPanicsOnNilContext(t *testing.T) {
+	pool := NewParwalkPool(nil, nil, 1)
+	defer pool.Close()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("run with nil context did not panic")
+		}
+	}()
+
+	_ = pool.run(
+		nil,
+		func(*parwalkRun) error {
+			return nil
+		},
+		nil,
+		ParwalkOptions{},
+	)
+}

--- a/go/client/parwalk_test.go
+++ b/go/client/parwalk_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+func TestParwalkWalkFromInode(t *testing.T) {
+	pool := NewParwalkPool(nil, nil, 1)
+	defer pool.Close()
+
+	file := msgs.MakeInodeId(msgs.FILE, 1, 1)
+	var called bool
+	err := pool.WalkFromInode(
+		context.Background(),
+		&ParwalkOptions{},
+		file,
+		"/some/file.txt",
+		func(
+			parent msgs.InodeId,
+			parentPath string,
+			name string,
+			_ msgs.TernTime,
+			id msgs.InodeId,
+			current bool,
+			owned bool,
+		) error {
+			called = true
+			if parent != msgs.NULL_INODE_ID ||
+				parentPath != "/some" ||
+				name != "file.txt" ||
+				id != file ||
+				!current ||
+				!owned {
+				t.Fatalf(
+					"callback got parent=%v parentPath=%q name=%q id=%v current=%v owned=%v",
+					parent,
+					parentPath,
+					name,
+					id,
+					current,
+					owned,
+				)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("callback was not called")
+	}
+}

--- a/go/client/recursivegrep.go
+++ b/go/client/recursivegrep.go
@@ -1,0 +1,294 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/XTXMarkets/ternfs/go/core/bufpool"
+	"github.com/XTXMarkets/ternfs/go/core/log"
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+// RecursiveGrepOptions describes one current-tree regular-expression search.
+type RecursiveGrepOptions struct {
+	Roots            []string
+	Pattern          *regexp.Regexp
+	MaxFileSize      uint64
+	MaxLineSize      int
+	ProgressInterval time.Duration
+	// Filter is called for every walked edge. Returning false excludes the
+	// entry; excluding a directory also prunes its subtree.
+	Filter func(string, msgs.InodeId) (bool, error)
+}
+
+// RecursiveGrepFileError reports a file which could not be completely searched.
+type RecursiveGrepFileError struct {
+	Path  string
+	Inode msgs.InodeId
+	Err   error
+}
+
+// RecursiveGrepStats is a point-in-time search progress snapshot.
+type RecursiveGrepStats struct {
+	FilesFound         uint64
+	FilesScanned       uint64
+	BytesScanned       uint64
+	MatchesFound       uint64
+	FilesSkippedBySize uint64
+	FileErrors         uint64
+}
+
+// RecursiveGrepCallbacks receives serialized output. Returning an error cancels the
+// search.
+type RecursiveGrepCallbacks struct {
+	Match     func(GrepMatch) error
+	FileError func(RecursiveGrepFileError) error
+	Progress  func(RecursiveGrepStats) error
+}
+
+// RecursiveGrep pairs a shared ParwalkPool with a shared limit on concurrent file
+// reads. Concurrent Grep calls share the same file-read budget.
+type RecursiveGrep struct {
+	parwalk *ParwalkPool
+	log     *log.Logger
+	client  *Client
+	bufPool *bufpool.BufPool
+	sem     chan struct{}
+}
+
+type recursiveGrepCounters struct {
+	filesFound         atomic.Uint64
+	filesScanned       atomic.Uint64
+	bytesScanned       atomic.Uint64
+	matchesFound       atomic.Uint64
+	filesSkippedBySize atomic.Uint64
+	fileErrors         atomic.Uint64
+}
+
+func (counters *recursiveGrepCounters) snapshot() RecursiveGrepStats {
+	return RecursiveGrepStats{
+		FilesFound:         counters.filesFound.Load(),
+		FilesScanned:       counters.filesScanned.Load(),
+		BytesScanned:       counters.bytesScanned.Load(),
+		MatchesFound:       counters.matchesFound.Load(),
+		FilesSkippedBySize: counters.filesSkippedBySize.Load(),
+		FileErrors:         counters.fileErrors.Load(),
+	}
+}
+
+type recursiveGrepRun struct {
+	ctx       context.Context
+	cancel    context.CancelCauseFunc
+	options   *RecursiveGrepOptions
+	callbacks RecursiveGrepCallbacks
+	counters  recursiveGrepCounters
+	pending   sync.WaitGroup
+	emitMutex sync.Mutex
+}
+
+func (run *recursiveGrepRun) emit(callback func() error) error {
+	run.emitMutex.Lock()
+	defer run.emitMutex.Unlock()
+	if err := context.Cause(run.ctx); err != nil {
+		return err
+	}
+	if err := callback(); err != nil {
+		run.cancel(err)
+		return err
+	}
+	return nil
+}
+
+// NewRecursiveGrep creates a recursive grep using parwalk for traversal.
+// grepWorkers bounds concurrent file reads across all Grep calls.
+func NewRecursiveGrep(parwalk *ParwalkPool, grepWorkers int) *RecursiveGrep {
+	if parwalk == nil {
+		panic("nil ParwalkPool")
+	}
+	if grepWorkers < 1 {
+		panic(fmt.Errorf("grepWorkers=%d < 1", grepWorkers))
+	}
+	return &RecursiveGrep{
+		parwalk: parwalk,
+		log:     parwalk.log,
+		client:  parwalk.client,
+		bufPool: bufpool.NewBufPool(),
+		sem:     make(chan struct{}, grepWorkers),
+	}
+}
+
+// Grep walks the roots and searches regular files. Individual file failures
+// are reported through FileError and do not stop the remaining search.
+//
+// Acquiring the file-read budget blocks inside the walk callback. The callback
+// holds a ParwalkPool shard worker while blocked, so another walk sharing that
+// pool may stall if it needs the same shard. Parwalk's inline scheduling
+// fallback prevents deadlock, but callers sharing a pool should account for
+// this loss of metadata concurrency.
+func (grep *RecursiveGrep) Grep(
+	ctx context.Context,
+	options *RecursiveGrepOptions,
+	callbacks RecursiveGrepCallbacks,
+) (RecursiveGrepStats, error) {
+	if options == nil {
+		return RecursiveGrepStats{}, errors.New("recursive grep options are required")
+	}
+	if len(options.Roots) == 0 {
+		return RecursiveGrepStats{}, errors.New("recursive grep requires at least one root")
+	}
+	if options.Pattern == nil {
+		return RecursiveGrepStats{}, errors.New("recursive grep pattern is required")
+	}
+
+	grepCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	run := &recursiveGrepRun{
+		ctx:       grepCtx,
+		cancel:    cancel,
+		options:   options,
+		callbacks: callbacks,
+	}
+
+	done := make(chan struct{})
+	var progressDone <-chan struct{}
+	if callbacks.Progress != nil && options.ProgressInterval > 0 {
+		finished := make(chan struct{})
+		progressDone = finished
+		go func() {
+			defer close(finished)
+			ticker := time.NewTicker(options.ProgressInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-grepCtx.Done():
+					return
+				case <-done:
+					return
+				case <-ticker.C:
+					_ = run.emit(func() error {
+						return callbacks.Progress(run.counters.snapshot())
+					})
+				}
+			}
+		}()
+	}
+
+	walkErr := grep.parwalk.WalkMany(
+		grepCtx,
+		&ParwalkOptions{},
+		options.Roots,
+		func(
+			_ msgs.InodeId,
+			parentPath string,
+			name string,
+			_ msgs.TernTime,
+			id msgs.InodeId,
+			_ bool,
+			_ bool,
+		) error {
+			fullPath := path.Join(parentPath, name)
+			if options.Filter != nil {
+				include, err := options.Filter(fullPath, id)
+				if err != nil {
+					return err
+				}
+				if !include {
+					return ErrSkipSubtree
+				}
+			}
+			if id.Type() != msgs.FILE {
+				return nil
+			}
+			run.pending.Add(1)
+			select {
+			case <-grepCtx.Done():
+				run.pending.Done()
+				return context.Cause(grepCtx)
+			case grep.sem <- struct{}{}:
+				run.counters.filesFound.Add(1)
+				go func() {
+					defer func() { <-grep.sem }()
+					defer run.pending.Done()
+					grep.grepFile(run, fullPath, id)
+				}()
+				return nil
+			}
+		},
+	)
+	run.pending.Wait()
+	close(done)
+	if progressDone != nil {
+		<-progressDone
+	}
+
+	stats := run.counters.snapshot()
+	if err := context.Cause(grepCtx); err != nil {
+		return stats, err
+	}
+	return stats, walkErr
+}
+
+func (grep *RecursiveGrep) grepFile(
+	run *recursiveGrepRun,
+	filePath string,
+	id msgs.InodeId,
+) {
+	bytesScanned, err := GrepFile(
+		run.ctx,
+		grep.log,
+		grep.client,
+		grep.bufPool,
+		filePath,
+		id,
+		run.options.Pattern,
+		run.options.MaxFileSize,
+		run.options.MaxLineSize,
+		func(match GrepMatch) error {
+			return run.emit(func() error {
+				run.counters.matchesFound.Add(1)
+				if run.callbacks.Match == nil {
+					return nil
+				}
+				return run.callbacks.Match(match)
+			})
+		},
+	)
+	run.counters.bytesScanned.Add(bytesScanned)
+	switch {
+	case err == nil:
+		run.counters.filesScanned.Add(1)
+	case errors.Is(err, ErrGrepFileTooLarge):
+		run.counters.filesSkippedBySize.Add(1)
+	case context.Cause(run.ctx) == nil:
+		grep.publishFileError(run, filePath, id, err)
+	}
+}
+
+func (grep *RecursiveGrep) publishFileError(
+	run *recursiveGrepRun,
+	filePath string,
+	id msgs.InodeId,
+	err error,
+) {
+	run.counters.fileErrors.Add(1)
+	_ = run.emit(func() error {
+		if run.callbacks.FileError == nil {
+			return nil
+		}
+		return run.callbacks.FileError(RecursiveGrepFileError{
+			Path:  filePath,
+			Inode: id,
+			Err:   err,
+		})
+	})
+}

--- a/go/client/recursivegrep_test.go
+++ b/go/client/recursivegrep_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRecursiveGrepEmitCancelsOnCallbackError(t *testing.T) {
+	callbackErr := errors.New("output failed")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	run := recursiveGrepRun{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	err := run.emit(func() error {
+		return callbackErr
+	})
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("error = %v, want %v", err, callbackErr)
+	}
+	if !errors.Is(context.Cause(ctx), callbackErr) {
+		t.Fatalf("context cause = %v, want %v", context.Cause(ctx), callbackErr)
+	}
+}

--- a/go/terncli/cmd/collect.go
+++ b/go/terncli/cmd/collect.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/cleanup"
@@ -60,12 +61,12 @@ func NewCollect() Command {
 					}
 				}
 			}()
-			err = client.Parwalk(
-				l,
-				runtime.getClient(),
+			pool := client.NewParwalkPool(l, runtime.getClient(), 100)
+			defer pool.Close()
+			err = pool.Walk(
+				context.Background(),
 				&client.ParwalkOptions{
-					WorkersPerShard: 100,
-					Snapshot:        *collectDirFollowSnapshot,
+					Snapshot: *collectDirFollowSnapshot,
 				},
 				*collectDirPath,
 				func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {

--- a/go/terncli/cmd/du.go
+++ b/go/terncli/cmd/du.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -93,12 +94,12 @@ func NewDu() Command {
 				}
 			}
 		}
-		err = client.Parwalk(
-			l,
-			c,
+		pool := client.NewParwalkPool(l, c, *duWorkersPerSshard)
+		defer pool.Close()
+		err = pool.Walk(
+			context.Background(),
 			&client.ParwalkOptions{
-				WorkersPerShard: *duWorkersPerSshard,
-				Snapshot:        *duSnapshot,
+				Snapshot: *duSnapshot,
 			},
 			*duDir,
 			func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {

--- a/go/terncli/cmd/filesizes.go
+++ b/go/terncli/cmd/filesizes.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -19,12 +20,11 @@ import (
 func outputFullFileSizes(log *log.Logger, c *client.Client) {
 	var examinedDirs uint64
 	var examinedFiles uint64
-	err := client.Parwalk(
-		log,
-		c,
-		&client.ParwalkOptions{
-			WorkersPerShard: 1,
-		},
+	pool := client.NewParwalkPool(log, c, 1)
+	defer pool.Close()
+	err := pool.Walk(
+		context.Background(),
+		&client.ParwalkOptions{},
 		"/",
 		func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {
 			if id.Type() == msgs.DIRECTORY {

--- a/go/terncli/cmd/find.go
+++ b/go/terncli/cmd/find.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -46,12 +47,12 @@ func NewFind() Command {
 			}
 		}
 		c := runtime.getClient()
-		err := client.Parwalk(
-			l,
-			c,
+		pool := client.NewParwalkPool(l, c, *findWorkersPerShard)
+		defer pool.Close()
+		err := pool.Walk(
+			context.Background(),
 			&client.ParwalkOptions{
-				WorkersPerShard: *findWorkersPerShard,
-				Snapshot:        *findSnapshot,
+				Snapshot: *findSnapshot,
 			},
 			*findDir,
 			func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {

--- a/go/terncli/cmd/grep.go
+++ b/go/terncli/cmd/grep.go
@@ -1,0 +1,196 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path"
+	"regexp"
+	"time"
+
+	"github.com/XTXMarkets/ternfs/go/client"
+	"github.com/XTXMarkets/ternfs/go/core/flags"
+	"github.com/XTXMarkets/ternfs/go/core/log"
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+var errGrepInterrupted = errors.New("grep interrupted")
+
+type grepParams struct {
+	roots            []string
+	expression       string
+	nameExpression   string
+	workersPerShard  int
+	fileWorkers      int
+	maxFileSize      uint64
+	maxLineSize      int
+	progressInterval time.Duration
+}
+
+func includeGrepName(pattern *regexp.Regexp, filePath string, id msgs.InodeId) bool {
+	return id.Type() != msgs.FILE || pattern.MatchString(path.Base(filePath))
+}
+
+func runGrep(
+	logger *log.Logger,
+	ternClient *client.Client,
+	params *grepParams,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	pattern, err := regexp.Compile(params.expression)
+	if err != nil {
+		return fmt.Errorf("compile regexp: %w", err)
+	}
+	var namePattern *regexp.Regexp
+	if params.nameExpression != "" {
+		namePattern, err = regexp.Compile(params.nameExpression)
+		if err != nil {
+			return fmt.Errorf("compile name regexp: %w", err)
+		}
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	parwalkPool := client.NewParwalkPool(logger, ternClient, params.workersPerShard)
+	defer parwalkPool.Close()
+	grep := client.NewRecursiveGrep(parwalkPool, params.fileWorkers)
+
+	options := &client.RecursiveGrepOptions{
+		Roots:            params.roots,
+		Pattern:          pattern,
+		MaxFileSize:      params.maxFileSize,
+		MaxLineSize:      params.maxLineSize,
+		ProgressInterval: params.progressInterval,
+	}
+	if namePattern != nil {
+		options.Filter = func(filePath string, id msgs.InodeId) (bool, error) {
+			return includeGrepName(namePattern, filePath, id), nil
+		}
+	}
+	stats, grepErr := grep.Grep(
+		ctx,
+		options,
+		client.RecursiveGrepCallbacks{
+			Match: func(match client.GrepMatch) error {
+				_, err := fmt.Fprintf(stdout, "%s:%d:%d:%s\n",
+					match.Path,
+					match.LineNumber,
+					match.ByteOffset,
+					match.Line,
+				)
+				return err
+			},
+			FileError: func(fileErr client.RecursiveGrepFileError) error {
+				_, err := fmt.Fprintf(stderr, "grep: %s: %v\n",
+					fileErr.Path, fileErr.Err)
+				return err
+			},
+			Progress: func(stats client.RecursiveGrepStats) error {
+				return writeGrepStats(stderr, "progress", stats)
+			},
+		},
+	)
+	if err := writeGrepStats(stderr, "done", stats); err != nil &&
+		grepErr == nil {
+		grepErr = err
+	}
+	if errors.Is(grepErr, context.Canceled) && ctx.Err() != nil {
+		return errGrepInterrupted
+	}
+	return grepErr
+}
+
+func writeGrepStats(
+	output io.Writer,
+	state string,
+	stats client.RecursiveGrepStats,
+) error {
+	_, err := fmt.Fprintf(
+		output,
+		"grep: %s: files_found=%d files_scanned=%d files_skipped_by_size=%d file_errors=%d bytes_scanned=%d matches_found=%d\n",
+		state,
+		stats.FilesFound,
+		stats.FilesScanned,
+		stats.FilesSkippedBySize,
+		stats.FileErrors,
+		stats.BytesScanned,
+		stats.MatchesFound,
+	)
+	return err
+}
+
+func NewGrep() Command {
+	grepCmd := flag.NewFlagSet("grep", flag.ExitOnError)
+	expression := grepCmd.String(
+		"regexp",
+		"",
+		"Go regular expression to search for. Matches are written as path:line:match-byte-offset:text.",
+	)
+	var roots flags.StringArrayFlags
+	grepCmd.Var(&roots, "root", "TernFS root path to search. May be repeated.")
+	nameExpression := grepCmd.String("name", "",
+		"Go regular expression matched against each file's base name.",
+	)
+	workersPerShard := grepCmd.Int("workers-per-shard", 5,
+		"Shared Parwalk workers per shard.",
+	)
+	fileWorkers := grepCmd.Int("file-workers", 8, "Maximum concurrent file readers.")
+	maxFileSize := grepCmd.Uint64("max-file-size", 0,
+		"Skip files larger than this many bytes; zero means unlimited.",
+	)
+	maxLineSize := grepCmd.Int("max-line-size", 0,
+		"Fail a file when an encoded line exceeds this many bytes; zero means the library default (1 MiB).",
+	)
+	progressInterval := grepCmd.Duration("progress-interval", 10*time.Second,
+		"Progress reporting interval; non-positive disables progress reports.",
+	)
+	run := func(runtime *Runtime) {
+		if *expression == "" {
+			fmt.Fprintln(os.Stderr, "grep: -regexp is required")
+			os.Exit(2)
+		}
+		if len(roots) == 0 {
+			fmt.Fprintln(os.Stderr, "grep: at least one -root is required")
+			os.Exit(2)
+		}
+		if *workersPerShard < 1 || *fileWorkers < 1 {
+			fmt.Fprintln(os.Stderr,
+				"grep: -workers-per-shard and -file-workers must each be at least 1",
+			)
+			os.Exit(2)
+		}
+		err := runGrep(
+			runtime.Log,
+			runtime.getClient(),
+			&grepParams{
+				roots:            []string(roots),
+				expression:       *expression,
+				nameExpression:   *nameExpression,
+				workersPerShard:  *workersPerShard,
+				fileWorkers:      *fileWorkers,
+				maxFileSize:      *maxFileSize,
+				maxLineSize:      *maxLineSize,
+				progressInterval: *progressInterval,
+			},
+			os.Stdout,
+			os.Stderr,
+		)
+		if errors.Is(err, errGrepInterrupted) {
+			os.Exit(130)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "grep: %v\n", err)
+			os.Exit(2)
+		}
+	}
+	return Command{Flags: grepCmd, Run: run}
+}

--- a/go/terncli/cmd/grep_test.go
+++ b/go/terncli/cmd/grep_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 XTX Markets Technologies Limited
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package cmd
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/XTXMarkets/ternfs/go/client"
+	"github.com/XTXMarkets/ternfs/go/msgs"
+)
+
+func TestRunGrepRejectsInvalidRegexpBeforeUsingClient(t *testing.T) {
+	err := runGrep(
+		nil,
+		nil,
+		&grepParams{expression: "["},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "compile regexp") {
+		t.Fatalf("error = %v, want regexp compilation error", err)
+	}
+}
+
+func TestRunGrepRejectsInvalidNameRegexpBeforeUsingClient(t *testing.T) {
+	err := runGrep(
+		nil,
+		nil,
+		&grepParams{expression: ".", nameExpression: "["},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "compile name regexp") {
+		t.Fatalf("error = %v, want name regexp compilation error", err)
+	}
+}
+
+func TestIncludeGrepName(t *testing.T) {
+	pattern := regexp.MustCompile(`\.go$`)
+	file := msgs.MakeInodeId(msgs.FILE, 1, 1)
+	directory := msgs.MakeInodeId(msgs.DIRECTORY, 1, 2)
+
+	if !includeGrepName(pattern, "/src/main.go", file) {
+		t.Fatal("matching file was excluded")
+	}
+	if includeGrepName(pattern, "/src/main.cc", file) {
+		t.Fatal("non-matching file was included")
+	}
+	if !includeGrepName(pattern, "/src/vendor", directory) {
+		t.Fatal("directory was excluded")
+	}
+}
+
+func TestWriteGrepStats(t *testing.T) {
+	var output bytes.Buffer
+	err := writeGrepStats(
+		&output,
+		"progress",
+		client.RecursiveGrepStats{
+			FilesFound:         8,
+			FilesScanned:       5,
+			BytesScanned:       1234,
+			MatchesFound:       3,
+			FilesSkippedBySize: 2,
+			FileErrors:         1,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "grep: progress: files_found=8 files_scanned=5 files_skipped_by_size=2 file_errors=1 bytes_scanned=1234 matches_found=3\n"
+	if output.String() != want {
+		t.Fatalf("output = %q, want %q", output.String(), want)
+	}
+}

--- a/go/terncli/cmd/resurrectsubtree.go
+++ b/go/terncli/cmd/resurrectsubtree.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -135,12 +136,16 @@ func NewResurrectSubtree() Command {
 		//    Parwalk descends, so children always find their parent.
 		var dstDirIds sync.Map
 		dstDirIds.Store(srcRootId, dstRootId)
-		err = client.ParwalkFromInode(
+		pool := client.NewParwalkPool(
 			l,
 			c,
+			*resurrectSubtreeWorkersPerShard,
+		)
+		defer pool.Close()
+		err = pool.WalkFromInode(
+			context.Background(),
 			&client.ParwalkOptions{
-				WorkersPerShard: *resurrectSubtreeWorkersPerShard,
-				SnapshotLatest:  true,
+				SnapshotLatest: true,
 			},
 			srcRootId,
 			dstRootPath,

--- a/go/terncli/cmd/rm.go
+++ b/go/terncli/cmd/rm.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -61,12 +62,11 @@ func NewRm() Command {
 		var numSkipped uint64
 		var numErrors uint64
 		startedAt := time.Now()
-		err := client.Parwalk(
-			l,
-			c,
-			&client.ParwalkOptions{
-				WorkersPerShard: *rmWorkersPerShard,
-			},
+		pool := client.NewParwalkPool(l, c, *rmWorkersPerShard)
+		defer pool.Close()
+		err := pool.Walk(
+			context.Background(),
+			&client.ParwalkOptions{},
 			*rmPath,
 			func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, id msgs.InodeId, current bool, owned bool) error {
 				if id.Type() == msgs.DIRECTORY {

--- a/go/terncli/cmd/tagfiles.go
+++ b/go/terncli/cmd/tagfiles.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
@@ -261,10 +262,11 @@ func runTagFiles(l *log.Logger, c *client.Client, p *tagFilesParams) error {
 		return nil
 	}
 
-	walkErr := client.ParwalkMany(
-		l,
-		c,
-		&client.ParwalkOptions{WorkersPerShard: p.workersPerShard},
+	pool := client.NewParwalkPool(l, c, p.workersPerShard)
+	defer pool.Close()
+	walkErr := pool.WalkMany(
+		context.Background(),
+		&client.ParwalkOptions{},
 		p.roots,
 		cb,
 	)

--- a/go/terncli/terncli.go
+++ b/go/terncli/terncli.go
@@ -56,6 +56,7 @@ func newCommands() map[string]terncmd.Command {
 		terncmd.NewResurrectSubtree(),
 		terncmd.NewResolveSamplePaths(),
 		terncmd.NewTagFiles(),
+		terncmd.NewGrep(),
 	} {
 		result[command.FlagSet().Name()] = command
 	}

--- a/go/terntests/fstest.go
+++ b/go/terntests/fstest.go
@@ -1176,8 +1176,10 @@ func fsTestInternal[Id comparable](
 		for i := range blockServices.BlockServices {
 			blockServicesById[blockServices.BlockServices[i].Id] = &blockServices.BlockServices[i]
 		}
-		client.Parwalk(
-			log, c, &client.ParwalkOptions{WorkersPerShard: 1}, "/",
+		pool := client.NewParwalkPool(log, c, 1)
+		defer pool.Close()
+		pool.Walk(
+			context.Background(), &client.ParwalkOptions{}, "/",
 			func(parent msgs.InodeId, parentPath string, name string, creationTime msgs.TernTime, fileId msgs.InodeId, current bool, owned bool) error {
 				if fileId.Type() == msgs.DIRECTORY {
 					return nil

--- a/go/terntests/parwalkmany.go
+++ b/go/terntests/parwalkmany.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/XTXMarkets/ternfs/go/client"
 	"github.com/XTXMarkets/ternfs/go/core/log"
@@ -22,7 +23,7 @@ type parwalkManyOpts struct {
 }
 
 // parwalkManyTest creates several disjoint root subtrees, walks them all
-// through a single ParwalkMany call, and checks:
+// through a single ParwalkPool.WalkMany call, and checks:
 //
 //  1. Every owned file inserted is reported exactly once.
 //  2. Every reported file lives under one of the seeded roots.
@@ -74,7 +75,7 @@ func parwalkManyTest(
 
 	// Concurrency observability: the parwalk callback runs on a shard
 	// goroutine. Track how many distinct shards are *simultaneously*
-	// inside the callback. If ParwalkMany shares a pool, this tops 1
+	// inside the callback. If WalkMany shares a pool, this tops 1
 	// the moment a second root is seeded and there's any work left for
 	// the first root.
 	var (
@@ -131,9 +132,11 @@ func parwalkManyTest(
 		return nil
 	}
 
-	if err := client.ParwalkMany(
-		logger, c,
-		&client.ParwalkOptions{WorkersPerShard: opts.workersPerShard},
+	pool := client.NewParwalkPool(logger, c, opts.workersPerShard)
+	defer pool.Close()
+	if err := pool.WalkMany(
+		context.Background(),
+		&client.ParwalkOptions{},
 		roots,
 		cb,
 	); err != nil {
@@ -144,7 +147,7 @@ func parwalkManyTest(
 	for id, name := range expected {
 		got, ok := seen[id]
 		if !ok {
-			panic(fmt.Errorf("file %v (%s) never visited by ParwalkMany", id, name))
+			panic(fmt.Errorf("file %v (%s) never visited by WalkMany", id, name))
 		}
 		if got != 1 {
 			panic(fmt.Errorf("file %v (%s) visited %d times, want 1", id, name, got))
@@ -156,20 +159,20 @@ func parwalkManyTest(
 	// Every visited file is one we created (no leakage from elsewhere
 	// in the test fs).
 	if len(seen) != len(expected) {
-		panic(fmt.Errorf("ParwalkMany visited %d files, expected %d", len(seen), len(expected)))
+		panic(fmt.Errorf("WalkMany visited %d files, expected %d", len(seen), len(expected)))
 	}
 	for name := range seenNames {
 		if _, want := expectedNames[name]; !want {
-			panic(fmt.Errorf("ParwalkMany visited unexpected path %s", name))
+			panic(fmt.Errorf("WalkMany visited unexpected path %s", name))
 		}
 	}
 
 	// Sanity: with multiple roots and >1 worker per shard, we expect to
 	// have observed at least 2 shard goroutines running concurrently in
-	// the callback at some point. If this fails, ParwalkMany is
+	// the callback at some point. If this fails, WalkMany is
 	// effectively serial — which would defeat the whole point.
 	if opts.numRoots > 1 && opts.dirsPerRoot*opts.filesPerDir > 1 && atomic.LoadInt32(&maxConc) < 2 {
-		panic(fmt.Errorf("ParwalkMany never had >=2 shards active concurrently (max=%d); pool not shared across roots", maxConc))
+		panic(fmt.Errorf("WalkMany never had >=2 shards active concurrently (max=%d); pool not shared across roots", maxConc))
 	}
 	logger.Info("parwalkMany visited %d files across %d roots; max concurrent shards observed = %d",
 		len(seen), len(roots), atomic.LoadInt32(&maxConc))

--- a/go/terntests/terntests.go
+++ b/go/terntests/terntests.go
@@ -405,7 +405,7 @@ func (r *RunTests) run(
 	)
 
 	if !r.kmod {
-		// ParwalkMany exercises the Go client API directly (CDC + shard
+		// WalkMany exercises the Go client API directly (CDC + shard
 		// RPCs) and has nothing to do with the kmod mount, so skip it on
 		// kmod runs to keep that suite focused.
 		parwalkManyOpts := &parwalkManyOpts{


### PR DESCRIPTION
## Summary

Adds recursive regular-expression search to the TernFS Go client and exposes it as terncli grep.

* Refactors Parwalk into a reusable, cancellable worker pool.
* Adds GrepFile for individual files and RecursiveGrep for directory trees.
* Bounds concurrent reads and supports file-size limits, filename filtering and progress reporting.
* Reports unreadable files without stopping the remaining search.
* Handles Ctrl-C cleanly.
