### PR TITLE
go/client: restore 10MiB UDP receive buffer for metadata socket

### DIFF
--- a/go/client/client.go
+++ b/go/client/client.go
@@ -256,8 +256,10 @@ func (cm *clientMetadata) init(log *log.Logger, client *Client) error {
 	}
 	cm.sock = sock.(*net.UDPConn)
 	// 10MiB/100byte ~ 100k requests in the pipe. 100byte is
-	// kinda conservative.
-	if err := cm.sock.SetReadBuffer(1 << 20); err != nil {
+	// kinda conservative. Note that the kernel silently clamps
+	// this to net.core.rmem_max, so the effective size may be
+	// much smaller than requested.
+	if err := cm.sock.SetReadBuffer(10 << 20); err != nil {
 		cm.sock.Close()
 		return err
 	}


### PR DESCRIPTION
The comment says 10MB, but the constant is 1MB. Chose the larger value.

Notes:
* At 10Gb/s this increases the pause duration that be survived from 0.8ms to 8ms. Our aggregate networking is faster than 10Gb/s too.
* This only matters on hosts that have bumped net.core.rmem_max to something larger than 1MB.
* On the C++ side we have `UDPSocketPair` which stays at 1MB because one server typically has many sockets open.

History:
* Commit [6ab2049d](https://github.com/XTXMarkets/ternfs/commit/6ab2049d) set the metadata socket receive buffer to 10MiB "to reduce spurious timeouts when the software can't keep up with the responses".
* Commit [cf0b1d25 ](https://github.com/XTXMarkets/ternfs/commit/cf0b1d25)(a self-review pass) added the comment explaining the 10MiB sizing and, in the same hunk, changed the constant to` 1 << 20`

